### PR TITLE
feat: add hookflow register command for personal hooks and skill

### DIFF
--- a/.github/hookflows/coverage.yaml
+++ b/.github/hookflows/coverage.yaml
@@ -1,7 +1,5 @@
-
 name: Test Coverage Enforcement
 description: Ensures code changes maintain minimum test coverage before commit
-
 
 on:
   commit:
@@ -12,7 +10,6 @@ on:
       - 'packages/**'
     paths-ignore:
       - '**/*.md'
-
 
 blocking: true
 

--- a/.github/hookflows/lint.yaml
+++ b/.github/hookflows/lint.yaml
@@ -1,5 +1,4 @@
-
-name: Lint Enforcement
+name: Lint Enforcement
 description: Runs golangci-lint before commit to catch lint errors early
 
 on:

--- a/README.md
+++ b/README.md
@@ -32,35 +32,25 @@ This turns post-lifecycle hooks into **blocking validators** — something the C
 - [GitHub CLI](https://cli.github.com/) (`gh`) installed and authenticated
 - [PowerShell Core](https://github.com/PowerShell/PowerShell) (`pwsh`) installed (workflow steps run in pwsh for cross-platform consistency)
 
-## Installation
+## Get Started in 2 Commands
 
 ```bash
 gh extension install htekdev/gh-hookflow
+gh hookflow register
 ```
 
-This installs gh-hookflow as `gh hookflow` and integrates directly with Copilot CLI hooks.
+That's it. Hookflow is now active for **every repo** you open with Copilot CLI. No per-repo setup needed — governance runs automatically.
 
-## Quick Start
+> `register` installs personal hooks at `~/.copilot/hooks/hooks.json` and the hookflow agent skill at `~/.copilot/skills/hookflow/SKILL.md`. These work across all repositories, with no project-level configuration required.
 
-### 1. Initialize gh-hookflow in your repository
+### Add repo-specific workflows
+
+Once registered globally, create workflows in any repo:
 
 ```bash
 cd your-project
-gh hookflow init
-```
-
-This creates:
-- `.github/hookflows/` — Directory for your workflow files
-- `.github/hooks/hooks.json` — Copilot CLI hook configuration
-- `.github/hookflows/example.yml` — Example workflow to get started
-- `.github/skills/hookflow/SKILL.md` — AI agent guidance for workflow creation
-
-### 2. Create a workflow
-
-Use AI to generate a workflow:
-
-```bash
-gh hookflow create "block edits to .env files"
+gh hookflow init --repo   # scaffolds .github/hookflows/ with an example workflow
+gh hookflow create "block edits to .env files"   # AI-generate a workflow
 ```
 
 Or manually create `.github/hookflows/block-env.yml`:
@@ -87,31 +77,33 @@ steps:
       exit 1
 ```
 
-### 3. Test your workflow
+### Test and share
 
 ```bash
-# Test with a mock file event
-gh hookflow test --event file --action edit --path ".env"
-
-# Test with a mock commit event  
-gh hookflow test --event commit --path src/app.ts
+gh hookflow test --event file --action edit --path ".env"   # test locally
+git add .github/ && git commit -m "Add hookflow workflows"  # share with team
 ```
 
-### 4. Commit and share
+Team members just need `gh extension install htekdev/gh-hookflow && gh hookflow register` to run your workflows during their Copilot sessions.
 
-```bash
-git add .github/
-git commit -m "Add gh-hookflow workflows"
-git push
-```
+### How `register` vs `init` work together
 
-Team members can install with `gh extension install htekdev/gh-hookflow` to automatically run your workflows during their Copilot sessions.
+| Command | Scope | What it does |
+|---------|-------|-------------|
+| `gh hookflow register` | **Global** (all repos) | Installs personal hooks + agent skill in `~/.copilot/`. Run once. |
+| `gh hookflow init` | **Per-repo** | Creates `.github/hooks/hooks.json` for repo-level hooks. |
+| `gh hookflow init --repo` | **Per-repo** | Also scaffolds `.github/hookflows/` with example workflow. |
+
+When both exist, repo hooks run first and personal hooks automatically defer (via the `--global` flag). This means repo-specific workflows always take priority.
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
-| `gh hookflow init` | Initialize gh-hookflow for a repository |
+| `gh hookflow register` | Register personal hooks and skill (global, all repos) |
+| `gh hookflow register --unregister` | Remove personal hooks and skill |
+| `gh hookflow init` | Initialize per-repo hooks |
+| `gh hookflow init --repo` | Also scaffold example workflows |
 | `gh hookflow create <prompt>` | Create a workflow using AI |
 | `gh hookflow discover` | List workflows in the current directory |
 | `gh hookflow validate` | Validate workflow YAML files |
@@ -177,8 +169,14 @@ The agent learns what went wrong and can fix it — turning a passive post-hook 
 ## Usage
 
 ```bash
-# Initialize a repository (creates .github/hookflows/ and .github/hooks/hooks.json)
+# One-time global setup (personal hooks + skill for all repos)
+gh hookflow register
+
+# Initialize a repository (creates .github/hooks/hooks.json)
 gh hookflow init
+
+# Initialize with example workflows
+gh hookflow init --repo
 
 # Discover workflows in the current directory
 gh hookflow discover

--- a/cmd/hookflow/init.go
+++ b/cmd/hookflow/init.go
@@ -19,8 +19,8 @@ Creates:
 With --repo flag, also creates:
 - .github/hookflows/example.yml - Example workflow
 
-For global hookflow across all repos, install the hookflow plugin:
-  copilot plugin install htekdev/hookflow-gh-copilot-plugin
+For global hookflow across all repos, run:
+  hookflow register
 
 After running init, you can create workflows using 'hookflow create'
 or by manually creating YAML files in .github/hookflows/`,
@@ -72,8 +72,8 @@ func runInit(dir string, force bool, repo bool) error {
 		fmt.Println("  2. Or edit the example workflow in .github/hookflows/example.yml")
 		fmt.Println("  3. Commit the .github/ directory to enable for your team")
 	}
-	fmt.Println("\nFor global hookflow across all repos, install the plugin:")
-	fmt.Println("  copilot plugin install htekdev/hookflow-gh-copilot-plugin")
+	fmt.Println("\nFor global hookflow across all repos, run:")
+	fmt.Println("  hookflow register")
 
 	return nil
 }

--- a/cmd/hookflow/register.go
+++ b/cmd/hookflow/register.go
@@ -1,0 +1,772 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+var registerCmd = &cobra.Command{
+	Use:   "register",
+	Short: "Register hookflow personal hooks and skill",
+	Long: `Registers hookflow hooks and skill for the current user.
+
+Creates or updates:
+- ~/.copilot/hooks/hooks.json — Personal hooks (preToolUse, postToolUse, sessionStart)
+- ~/.copilot/skills/hookflow/SKILL.md — Agent skill for workflow creation guidance
+
+Hookflow hooks are registered with --global flag so they defer to repo-level
+hooks when both exist. Existing hookflow hooks are detected and replaced;
+non-hookflow hooks are preserved.
+
+Use --unregister to remove hookflow hooks and skill.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		unregister, _ := cmd.Flags().GetBool("unregister")
+		hooksOnly, _ := cmd.Flags().GetBool("hooks-only")
+		skillOnly, _ := cmd.Flags().GetBool("skill-only")
+
+		return runRegister(unregister, hooksOnly, skillOnly)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(registerCmd)
+	registerCmd.Flags().Bool("unregister", false, "Remove hookflow hooks and skill")
+	registerCmd.Flags().Bool("hooks-only", false, "Only register hooks (skip skill)")
+	registerCmd.Flags().Bool("skill-only", false, "Only register skill (skip hooks)")
+}
+
+func runRegister(unregister, hooksOnly, skillOnly bool) error {
+	if unregister {
+		return runUnregister(hooksOnly, skillOnly)
+	}
+
+	doHooks := !skillOnly
+	doSkill := !hooksOnly
+
+	if doHooks {
+		if err := registerPersonalHooks(); err != nil {
+			return err
+		}
+	}
+
+	if doSkill {
+		if err := registerSkill(); err != nil {
+			return err
+		}
+	}
+
+	fmt.Println("\n✓ hookflow registered successfully!")
+	if doHooks && doSkill {
+		fmt.Println("\nPersonal hooks and skill are now active for all repos.")
+	} else if doHooks {
+		fmt.Println("\nPersonal hooks are now active for all repos.")
+	} else {
+		fmt.Println("\nHookflow skill is now available.")
+	}
+	fmt.Println("\nNext steps:")
+	fmt.Println("  1. Initialize a repo: hookflow init")
+	fmt.Println("  2. Create a workflow: hookflow create \"block edits to .env files\"")
+
+	return nil
+}
+
+func runUnregister(hooksOnly, skillOnly bool) error {
+	doHooks := !skillOnly
+	doSkill := !hooksOnly
+
+	if doHooks {
+		if err := unregisterPersonalHooks(); err != nil {
+			return err
+		}
+	}
+
+	if doSkill {
+		if err := unregisterSkill(); err != nil {
+			return err
+		}
+	}
+
+	fmt.Println("\n✓ hookflow unregistered successfully!")
+	return nil
+}
+
+// registerPersonalHooks creates or merges hookflow hooks into ~/.copilot/hooks/hooks.json
+func registerPersonalHooks() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to determine home directory: %w", err)
+	}
+
+	hooksDir := filepath.Join(homeDir, ".copilot", "hooks")
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		return fmt.Errorf("failed to create hooks directory: %w", err)
+	}
+
+	hooksFile := filepath.Join(hooksDir, "hooks.json")
+	if err := mergePersonalHooksJSON(hooksFile); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// unregisterPersonalHooks removes hookflow hooks from ~/.copilot/hooks/hooks.json
+func unregisterPersonalHooks() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to determine home directory: %w", err)
+	}
+
+	hooksFile := filepath.Join(homeDir, ".copilot", "hooks", "hooks.json")
+
+	data, err := os.ReadFile(hooksFile)
+	if os.IsNotExist(err) {
+		fmt.Println("⚠ No personal hooks.json found — nothing to unregister")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to read hooks.json: %w", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(data, &config); err != nil {
+		fmt.Println("⚠ hooks.json is invalid JSON — nothing to unregister")
+		return nil
+	}
+
+	hooks, ok := config["hooks"].(map[string]interface{})
+	if !ok {
+		fmt.Println("⚠ hooks.json has no hooks — nothing to unregister")
+		return nil
+	}
+
+	// Remove hookflow hooks from each lifecycle
+	changed := false
+	for _, key := range []string{"preToolUse", "postToolUse", "sessionStart"} {
+		arr := getHookArray(hooks, key)
+		if containsHookflowHook(arr) {
+			hooks[key] = removeHookflowHooks(arr)
+			changed = true
+		}
+	}
+
+	if !changed {
+		fmt.Println("⚠ No hookflow hooks found in hooks.json")
+		return nil
+	}
+
+	// Clean up empty arrays
+	for _, key := range []string{"preToolUse", "postToolUse", "sessionStart"} {
+		arr := getHookArray(hooks, key)
+		if len(arr) == 0 {
+			delete(hooks, key)
+		}
+	}
+
+	// If no hooks remain, remove the file entirely
+	if len(hooks) == 0 {
+		if err := os.Remove(hooksFile); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove empty hooks.json: %w", err)
+		}
+		fmt.Printf("✓ Removed %s (no remaining hooks)\n", hooksFile)
+		return nil
+	}
+
+	jsonBytes, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal hooks.json: %w", err)
+	}
+
+	if err := os.WriteFile(hooksFile, jsonBytes, 0644); err != nil {
+		return fmt.Errorf("failed to write hooks.json: %w", err)
+	}
+
+	fmt.Printf("✓ Removed hookflow hooks from %s (preserved other hooks)\n", hooksFile)
+	return nil
+}
+
+// registerSkill writes the SKILL.md to ~/.copilot/skills/hookflow/SKILL.md
+func registerSkill() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to determine home directory: %w", err)
+	}
+
+	skillDir := filepath.Join(homeDir, ".copilot", "skills", "hookflow")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		return fmt.Errorf("failed to create skill directory: %w", err)
+	}
+
+	skillFile := filepath.Join(skillDir, "SKILL.md")
+	if err := os.WriteFile(skillFile, []byte(generateRegisterSkillMD()), 0644); err != nil {
+		return fmt.Errorf("failed to write SKILL.md: %w", err)
+	}
+
+	fmt.Printf("✓ Created %s\n", skillFile)
+	return nil
+}
+
+// unregisterSkill removes the hookflow skill directory
+func unregisterSkill() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to determine home directory: %w", err)
+	}
+
+	skillDir := filepath.Join(homeDir, ".copilot", "skills", "hookflow")
+	if _, err := os.Stat(skillDir); os.IsNotExist(err) {
+		fmt.Println("⚠ No hookflow skill found — nothing to unregister")
+		return nil
+	}
+
+	if err := os.RemoveAll(skillDir); err != nil {
+		return fmt.Errorf("failed to remove skill directory: %w", err)
+	}
+
+	fmt.Printf("✓ Removed %s\n", skillDir)
+	return nil
+}
+
+// mergePersonalHooksJSON creates or merges hookflow hooks into ~/.copilot/hooks/hooks.json.
+// Uses --global flag so personal hooks defer to repo hooks when both exist.
+func mergePersonalHooksJSON(path string) error {
+	hookflowPreHook := map[string]interface{}{
+		"type":       "command",
+		"bash":       "gh hookflow run --raw --event-type preToolUse --global",
+		"powershell": "gh hookflow run --raw --event-type preToolUse --global",
+		"timeoutSec": 1800,
+	}
+	hookflowPostHook := map[string]interface{}{
+		"type":       "command",
+		"bash":       "gh hookflow run --raw --event-type postToolUse --global",
+		"powershell": "gh hookflow run --raw --event-type postToolUse --global",
+		"timeoutSec": 1800,
+	}
+	sessionStartHook := map[string]interface{}{
+		"type":       "command",
+		"bash":       `gh hookflow check-setup || echo '{"systemMessage":"⚠️ hookflow not configured. Run: gh extension install htekdev/gh-hookflow && gh hookflow register"}'`,
+		"powershell": `gh hookflow check-setup; if ($LASTEXITCODE -ne 0) { Write-Output '{"systemMessage":"hookflow not configured. Run: gh extension install htekdev/gh-hookflow; gh hookflow register"}' }`,
+		"timeoutSec": 1800,
+		"comment":    "Ensure gh hookflow extension is installed",
+	}
+
+	config := map[string]interface{}{
+		"version": 1,
+		"hooks":   map[string]interface{}{},
+	}
+
+	if data, err := os.ReadFile(path); err == nil {
+		if err := json.Unmarshal(data, &config); err != nil {
+			_ = os.Rename(path, path+".bak")
+			fmt.Printf("⚠ Backed up invalid %s to %s.bak\n", path, path)
+			config = map[string]interface{}{
+				"version": 1,
+				"hooks":   map[string]interface{}{},
+			}
+		}
+	}
+
+	hooks, ok := config["hooks"].(map[string]interface{})
+	if !ok {
+		hooks = map[string]interface{}{}
+		config["hooks"] = hooks
+	}
+
+	// Always replace hookflow hooks (remove old, add new)
+	preToolUse := getHookArray(hooks, "preToolUse")
+	preToolUse = removeHookflowHooks(preToolUse)
+	preToolUse = append(preToolUse, hookflowPreHook)
+	hooks["preToolUse"] = preToolUse
+
+	postToolUse := getHookArray(hooks, "postToolUse")
+	postToolUse = removeHookflowHooks(postToolUse)
+	postToolUse = append(postToolUse, hookflowPostHook)
+	hooks["postToolUse"] = postToolUse
+
+	sessionStart := getHookArray(hooks, "sessionStart")
+	sessionStart = removeHookflowHooks(sessionStart)
+	sessionStart = append(sessionStart, sessionStartHook)
+	hooks["sessionStart"] = sessionStart
+
+	jsonBytes, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal hooks.json: %w", err)
+	}
+
+	if err := os.WriteFile(path, jsonBytes, 0644); err != nil {
+		return fmt.Errorf("failed to write hooks.json: %w", err)
+	}
+
+	fmt.Printf("✓ Created %s (personal hooks: preToolUse, postToolUse, sessionStart)\n", path)
+	return nil
+}
+
+// generateRegisterSkillMD creates the comprehensive SKILL.md for the hookflow skill.
+func generateRegisterSkillMD() string {
+	return `---
+name: hookflow
+description: Create and manage hookflow workflows for agent governance. Use this skill when creating, editing, or troubleshooting workflow files in .github/hookflows/. Trigger phrases include "create workflow", "block file edits", "add validation", "hookflow", "agent gate".
+---
+
+# Hookflow Workflow Creation
+
+This skill helps you create hookflow workflow files that enforce governance during AI agent sessions.
+
+## When to Use This Skill
+
+- Creating new workflow files in ` + "`" + `.github/hookflows/` + "`" + `
+- Editing existing hookflow workflows
+- Troubleshooting workflow triggers or validation
+- Understanding the hookflow schema
+
+## Quick Reference
+
+| Command | Description |
+|---------|-------------|
+| ` + "`" + `hookflow register` + "`" + ` | Register personal hooks and skill |
+| ` + "`" + `hookflow register --unregister` + "`" + ` | Remove personal hooks and skill |
+| ` + "`" + `hookflow init` + "`" + ` | Initialize per-repo hooks |
+| ` + "`" + `hookflow init --repo` + "`" + ` | Also create example workflow and scaffolding |
+| ` + "`" + `hookflow create "prompt"` + "`" + ` | AI-generate a workflow from description |
+| ` + "`" + `hookflow validate` + "`" + ` | Validate all workflows in repo |
+| ` + "`" + `hookflow test` + "`" + ` | Test a workflow with simulated events |
+| ` + "`" + `hookflow logs` + "`" + ` | View hookflow runtime logs |
+
+## Workflow Schema
+
+### Required Fields
+
+` + "```yaml" + `
+name: string          # Human-readable workflow name (required)
+on: object            # Trigger configuration (required)
+steps: array          # Steps to execute (required)
+` + "```" + `
+
+### Optional Fields
+
+` + "```yaml" + `
+description: string   # What the workflow does
+blocking: boolean     # Block on failure (default: true)
+env: object           # Environment variables for all steps
+concurrency:          # Concurrency control
+  group: string       # Concurrency group identifier
+  max-parallel: int   # Max parallel executions (default: 1)
+` + "```" + `
+
+## Trigger Types
+
+### Lifecycle (pre vs post)
+
+All triggers support a ` + "`lifecycle`" + ` field:
+
+- **pre** (default): Runs BEFORE the action — can block/deny the operation
+- **post**: Runs AFTER the action — for validation, linting, notifications
+
+` + "```yaml" + `
+# Block before file is created (pre)
+on:
+  file:
+    lifecycle: pre
+    paths: ['**/*.env']
+    types: [create]
+
+# Lint after file is edited (post)
+on:
+  file:
+    lifecycle: post
+    paths: ['**/*.ts']
+    types: [edit]
+` + "```" + `
+
+### File Trigger
+
+Matches file create/edit/delete operations.
+
+` + "```yaml" + `
+on:
+  file:
+    lifecycle: pre        # pre (default) or post
+    paths:                # File patterns to match (glob supported)
+      - '**/*.env'
+      - 'secrets/**'
+    paths-ignore:         # Patterns to exclude
+      - '**/*.md'
+    types:                # Event types: create, edit, delete
+      - edit
+      - create
+` + "```" + `
+
+### Tool Trigger
+
+Matches specific tool calls with argument patterns.
+
+` + "```yaml" + `
+# Single tool trigger
+on:
+  tool:
+    name: edit          # Tool name: edit, create, powershell, bash, etc.
+    args:
+      path: '**/secrets/**'  # Glob pattern for argument values
+    if: contains(event.tool.args.path, 'secret')  # Optional expression condition
+` + "```" + `
+
+### Multiple Tool Triggers
+
+Match multiple tools in a single workflow.
+
+` + "```yaml" + `
+on:
+  tools:
+    - name: powershell
+      args:
+        command: '*rm -rf*'
+    - name: bash
+      args:
+        command: '*rm -rf*'
+` + "```" + `
+
+### Commit Trigger
+
+Matches git commit events.
+
+` + "```yaml" + `
+on:
+  commit:
+    lifecycle: pre        # pre (default) or post
+    paths:                # Files that must be in the commit
+      - 'src/**'
+    paths-ignore:
+      - '**/*.md'
+    branches:             # Branch filters
+      - main
+    branches-ignore:      # Branches to exclude
+      - 'experimental/*'
+` + "```" + `
+
+### Push Trigger
+
+Matches git push events. Pushes must go through ` + "`" + `gh hookflow git-push` + "`" + `.
+
+` + "```yaml" + `
+on:
+  push:
+    lifecycle: pre        # pre (default) or post
+    branches:
+      - main
+      - 'release/*'
+    branches-ignore:
+      - 'experimental/*'
+    tags:
+      - 'v*'
+    tags-ignore:
+      - '*-rc*'
+    paths:                # File path filters
+      - 'src/**'
+    paths-ignore:
+      - '**/*.md'
+` + "```" + `
+
+## Expression Syntax
+
+Use ` + "`${{ }}`" + ` for dynamic values:
+
+### Event Context
+
+| Expression | Description |
+|------------|-------------|
+| ` + "`${{ event.file.path }}`" + ` | Path of file being edited |
+| ` + "`${{ event.file.action }}`" + ` | Action: edit, create, delete |
+| ` + "`${{ event.file.content }}`" + ` | File content (for create) |
+| ` + "`${{ event.tool.name }}`" + ` | Tool name being called |
+| ` + "`${{ event.tool.args.path }}`" + ` | Tool argument value |
+| ` + "`${{ event.tool.args.new_str }}`" + ` | New content (for edit, pre only) |
+| ` + "`${{ event.commit.message }}`" + ` | Commit message |
+| ` + "`${{ event.commit.sha }}`" + ` | Commit SHA |
+| ` + "`${{ event.lifecycle }}`" + ` | Hook lifecycle: pre or post |
+| ` + "`${{ event.cwd }}`" + ` | Working directory (absolute) |
+| ` + "`${{ env.MY_VAR }}`" + ` | Environment variable |
+| ` + "`${{ steps.step_name.outcome }}`" + ` | Previous step outcome |
+| ` + "`${{ steps.step_name.outputs }}`" + ` | Previous step outputs |
+
+**Note:** ` + "`event.tool.args.new_str`" + ` is only available during **pre** lifecycle for edit operations.
+For **post** lifecycle, use shell commands to read the actual file from disk.
+
+### String Functions
+
+| Function | Example |
+|----------|---------|
+| ` + "`contains(str, substr)`" + ` | ` + "`${{ contains(event.file.path, '.env') }}`" + ` |
+| ` + "`startsWith(str, prefix)`" + ` | ` + "`${{ startsWith(event.file.path, 'src/') }}`" + ` |
+| ` + "`endsWith(str, suffix)`" + ` | ` + "`${{ endsWith(event.file.path, '.ts') }}`" + ` |
+| ` + "`format(fmt, ...args)`" + ` | ` + "`${{ format('File: {0}', event.file.path) }}`" + ` |
+| ` + "`join(array, sep)`" + ` | ` + "`${{ join(event.commit.files, ', ') }}`" + ` |
+| ` + "`toJSON(value)`" + ` | ` + "`${{ toJSON(event) }}`" + ` |
+| ` + "`fromJSON(str)`" + ` | ` + "`${{ fromJSON(steps.data.outputs) }}`" + ` |
+
+### Step Outcome Functions
+
+Use in ` + "`if:`" + ` conditions to control step execution based on previous step results:
+
+| Function | Description |
+|----------|-------------|
+| ` + "`success()`" + ` | True if no previous steps failed or were cancelled |
+| ` + "`failure()`" + ` | True if any previous step failed |
+| ` + "`always()`" + ` | Always true — step runs regardless of previous failures |
+| ` + "`cancelled()`" + ` | True if any previous step was cancelled |
+
+` + "```yaml" + `
+steps:
+  - name: Run tests
+    run: |
+      go test ./...
+
+  - name: Report failure
+    if: failure()
+    run: |
+      echo "Tests failed — notifying team"
+
+  - name: Always cleanup
+    if: always()
+    run: |
+      rm -f temp-files/*
+` + "```" + `
+
+### Transcript Functions
+
+Query the session transcript to inspect what the agent has done previously:
+
+| Function | Description |
+|----------|-------------|
+| ` + "`transcript()`" + ` | All transcript entries as JSON array |
+| ` + "`transcript(regex)`" + ` | Entries matching regex pattern |
+| ` + "`transcript_since(regex)`" + ` | Entries after last match of regex |
+| ` + "`transcript_count(regex)`" + ` | Count of entries matching regex |
+| ` + "`transcript_last(regex)`" + ` | Last entry matching regex as JSON string |
+
+` + "```yaml" + `
+# Require tests before allowing source commits
+steps:
+  - name: Check for test runs
+    if: ${{ transcript_count('go test') == 0 }}
+    run: |
+      echo "No test runs found in session — run tests before committing"
+      exit 1
+` + "```" + `
+
+### Operators
+
+- Logical: ` + "`||`" + ` (OR), ` + "`&&`" + ` (AND), ` + "`!`" + ` (NOT)
+- Comparison: ` + "`==`" + `, ` + "`!=`" + `, ` + "`<`" + `, ` + "`<=`" + `, ` + "`>`" + `, ` + "`>=`" + `
+- Property access: ` + "`.`" + ` (dot notation)
+- Index access: ` + "`[]`" + ` (array/map indexing)
+
+## Step Configuration
+
+` + "```yaml" + `
+steps:
+  - name: Step name              # Human-readable name (optional)
+    if: ${{ condition }}         # Conditional execution (optional)
+    run: |                       # Shell command (required unless uses: is set)
+      echo "Running step"
+      # exit 1 to deny/block
+    shell: pwsh                  # Shell: pwsh (default), bash, sh, cmd
+    env:                         # Step-specific env vars (optional)
+      MY_VAR: value
+    working-directory: ./src     # Working directory (optional)
+    timeout: 60                  # Timeout in seconds (optional)
+    continue-on-error: true      # Continue workflow on failure (optional)
+` + "```" + `
+
+### Reusable Actions
+
+` + "```yaml" + `
+steps:
+  - name: Use a reusable action
+    uses: my-action              # Reference to action
+    with:                        # Input parameters
+      param1: value1
+      param2: value2
+` + "```" + `
+
+## Common Patterns
+
+### Block Sensitive Files
+
+` + "```yaml" + `
+name: Block Sensitive Files
+on:
+  file:
+    paths:
+      - '**/.env*'
+      - '**/secrets/**'
+      - '**/*.pem'
+      - '**/*.key'
+    types: [edit, create]
+blocking: true
+steps:
+  - name: Deny sensitive file access
+    run: |
+      echo "Cannot modify sensitive file: ${{ event.file.path }}"
+      exit 1
+` + "```" + `
+
+### Validate JSON Files (Post-Edit)
+
+` + "```yaml" + `
+name: Validate JSON
+on:
+  file:
+    lifecycle: post
+    paths: ['**/*.json']
+    types: [edit, create]
+blocking: true
+steps:
+  - name: Check JSON syntax
+    run: |
+      $content = Get-Content "${{ event.file.path }}" -Raw
+      try {
+        $content | ConvertFrom-Json | Out-Null
+        Write-Host "Valid JSON"
+      } catch {
+        Write-Error "Invalid JSON in ${{ event.file.path }}"
+        exit 1
+      }
+` + "```" + `
+
+### Post-Edit Linting (TypeScript)
+
+` + "```yaml" + `
+name: Post-Edit TypeScript Lint
+on:
+  file:
+    lifecycle: post
+    paths: ['**/*.ts', '**/*.tsx']
+    types: [edit]
+blocking: false
+steps:
+  - name: Run ESLint
+    run: |
+      npx eslint "${{ event.file.path }}" --fix
+      echo "Linting complete"
+` + "```" + `
+
+### Block Hardcoded Passwords (Pre-Edit)
+
+` + "```yaml" + `
+name: Block Hardcoded Passwords
+on:
+  file:
+    lifecycle: pre
+    paths: ['**/*.js', '**/*.ts', '**/*.py']
+    types: [edit, create]
+blocking: true
+steps:
+  - name: Check for passwords
+    if: contains(event.tool.args.new_str, 'password')
+    run: |
+      echo "Hardcoded password detected in edit"
+      exit 1
+` + "```" + `
+
+### Require Tests for Source Changes
+
+` + "```yaml" + `
+name: Require Tests
+on:
+  commit:
+    paths: ['src/**']
+    paths-ignore: ['src/**/*.test.*']
+blocking: true
+steps:
+  - name: Check for test files
+    run: |
+      $files = "${{ event.commit.files }}"
+      if ($files -notmatch '\.test\.') {
+        Write-Error "Source changes require accompanying tests"
+        exit 1
+      }
+` + "```" + `
+
+### Enforce Conventional Commits
+
+` + "```yaml" + `
+name: Conventional Commits
+on:
+  commit:
+    lifecycle: pre
+blocking: true
+steps:
+  - name: Check commit message format
+    run: |
+      $msg = "${{ event.commit.message }}"
+      if ($msg -notmatch '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?!?:') {
+        Write-Error "Commit message must follow conventional format: type(scope): description"
+        exit 1
+      }
+` + "```" + `
+
+### Protect Hookflow Governance
+
+` + "```yaml" + `
+name: Protect Hookflows
+on:
+  file:
+    lifecycle: pre
+    paths: ['.github/hookflows/**']
+    types: [edit, create]
+blocking: true
+steps:
+  - name: Block weakening governance
+    run: |
+      $content = '${{ event.file.content }}'
+      if ($content -match 'blocking:\s*false') {
+        Write-Error "Cannot set blocking: false on governance workflows"
+        exit 1
+      }
+` + "```" + `
+
+## Troubleshooting
+
+### Workflow Not Triggering
+
+1. Check trigger type matches event (file vs tool vs commit vs push)
+2. Verify path patterns use correct glob syntax
+3. Ensure ` + "`types`" + ` field matches the action (edit/create/delete)
+4. Check ` + "`lifecycle`" + ` matches hook type (pre = preToolUse, post = postToolUse)
+5. Run ` + "`hookflow logs`" + ` to see what events hookflow received
+
+### Pre vs Post Confusion
+
+- **pre** workflows run in ` + "`preToolUse`" + ` hook — can block actions
+- **post** workflows run in ` + "`postToolUse`" + ` hook — run after action completes
+- Default is ` + "`pre`" + ` if not specified
+
+### Validation Errors
+
+` + "```bash" + `
+gh hookflow validate
+gh hookflow validate --file .github/hookflows/my-workflow.yml
+` + "```" + `
+
+### Testing Workflows
+
+` + "```bash" + `
+gh hookflow test --workflow my-workflow --event file --path "test.env"
+` + "```" + `
+
+### Git Push
+
+All pushes must go through hookflow governance:
+
+` + "```bash" + `
+gh hookflow git-push origin main
+gh hookflow git-push-status <activity-id>
+` + "```" + `
+
+Never use ` + "`git push`" + ` directly — it is blocked by hookflow primitive guards.
+`
+}

--- a/cmd/hookflow/register_test.go
+++ b/cmd/hookflow/register_test.go
@@ -1,0 +1,752 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRegisterCreatesPersonalHooksAndSkill tests the happy path: register creates both hooks and skill
+func TestRegisterCreatesPersonalHooksAndSkill(t *testing.T) {
+	homeDir := t.TempDir()
+	origHome := overrideHomeDir(t, homeDir)
+	defer restoreHomeDir(origHome)
+
+	if err := runRegister(false, false, false); err != nil {
+		t.Fatalf("runRegister failed: %v", err)
+	}
+
+	// Verify hooks.json exists
+	hooksPath := filepath.Join(homeDir, ".copilot", "hooks", "hooks.json")
+	assertFileExists(t, hooksPath)
+
+	// Verify hooks.json content
+	hooksData, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("failed to read hooks.json: %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(hooksData, &config); err != nil {
+		t.Fatalf("hooks.json is invalid JSON: %v", err)
+	}
+
+	hooks := config["hooks"].(map[string]interface{})
+
+	// Verify all three hook types exist
+	for _, hookType := range []string{"preToolUse", "postToolUse", "sessionStart"} {
+		arr, ok := hooks[hookType].([]interface{})
+		if !ok || len(arr) == 0 {
+			t.Errorf("hooks.json missing %s hooks", hookType)
+		}
+	}
+
+	// Verify --global flag in preToolUse and postToolUse
+	hooksStr := string(hooksData)
+	if !strings.Contains(hooksStr, "--global") {
+		t.Error("personal hooks should contain --global flag")
+	}
+
+	// Verify SKILL.md exists
+	skillPath := filepath.Join(homeDir, ".copilot", "skills", "hookflow", "SKILL.md")
+	assertFileExists(t, skillPath)
+
+	// Verify SKILL.md content
+	skillData, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("failed to read SKILL.md: %v", err)
+	}
+	skillContent := string(skillData)
+
+	requiredSections := []string{
+		"name: hookflow",
+		"description:",
+		"Workflow Schema",
+		"Trigger Types",
+		"Expression Syntax",
+		"Transcript Functions",
+		"Step Outcome Functions",
+		"Common Patterns",
+		"hookflow register",
+	}
+
+	for _, section := range requiredSections {
+		if !strings.Contains(skillContent, section) {
+			t.Errorf("SKILL.md missing required section: %s", section)
+		}
+	}
+}
+
+// TestRegisterIdempotent tests that running register twice doesn't duplicate hooks
+func TestRegisterIdempotent(t *testing.T) {
+	homeDir := t.TempDir()
+	origHome := overrideHomeDir(t, homeDir)
+	defer restoreHomeDir(origHome)
+
+	// Register twice
+	if err := runRegister(false, false, false); err != nil {
+		t.Fatalf("first runRegister failed: %v", err)
+	}
+	if err := runRegister(false, false, false); err != nil {
+		t.Fatalf("second runRegister failed: %v", err)
+	}
+
+	// Read hooks.json
+	hooksPath := filepath.Join(homeDir, ".copilot", "hooks", "hooks.json")
+	hooksData, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("failed to read hooks.json: %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(hooksData, &config); err != nil {
+		t.Fatalf("hooks.json is invalid JSON: %v", err)
+	}
+
+	hooks := config["hooks"].(map[string]interface{})
+
+	// Verify exactly one hookflow hook per lifecycle
+	for _, hookType := range []string{"preToolUse", "postToolUse", "sessionStart"} {
+		arr := hooks[hookType].([]interface{})
+		hookflowCount := 0
+		for _, h := range arr {
+			hookBytes, _ := json.Marshal(h)
+			if strings.Contains(string(hookBytes), "hookflow") {
+				hookflowCount++
+			}
+		}
+		if hookflowCount != 1 {
+			t.Errorf("expected exactly 1 hookflow %s hook, got %d", hookType, hookflowCount)
+		}
+	}
+}
+
+// TestRegisterPreservesExistingHooks tests that non-hookflow hooks are preserved
+func TestRegisterPreservesExistingHooks(t *testing.T) {
+	homeDir := t.TempDir()
+	origHome := overrideHomeDir(t, homeDir)
+	defer restoreHomeDir(origHome)
+
+	// Create existing hooks.json with custom hooks
+	hooksDir := filepath.Join(homeDir, ".copilot", "hooks")
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		t.Fatalf("failed to create hooks dir: %v", err)
+	}
+
+	existingConfig := map[string]interface{}{
+		"version": 1,
+		"hooks": map[string]interface{}{
+			"preToolUse": []interface{}{
+				map[string]interface{}{
+					"type": "command",
+					"bash": "echo 'my custom pre hook'",
+				},
+			},
+			"postToolUse": []interface{}{
+				map[string]interface{}{
+					"type": "command",
+					"bash": "echo 'my custom post hook'",
+				},
+			},
+		},
+	}
+	existingJSON, _ := json.MarshalIndent(existingConfig, "", "  ")
+	hooksFile := filepath.Join(hooksDir, "hooks.json")
+	if err := os.WriteFile(hooksFile, existingJSON, 0644); err != nil {
+		t.Fatalf("failed to create hooks.json: %v", err)
+	}
+
+	// Register hookflow
+	if err := runRegister(false, false, false); err != nil {
+		t.Fatalf("runRegister failed: %v", err)
+	}
+
+	// Read merged hooks.json
+	hooksData, err := os.ReadFile(hooksFile)
+	if err != nil {
+		t.Fatalf("failed to read hooks.json: %v", err)
+	}
+
+	hooksStr := string(hooksData)
+
+	// Custom hooks should be preserved
+	if !strings.Contains(hooksStr, "my custom pre hook") {
+		t.Error("existing custom preToolUse hook should be preserved")
+	}
+	if !strings.Contains(hooksStr, "my custom post hook") {
+		t.Error("existing custom postToolUse hook should be preserved")
+	}
+
+	// Hookflow hooks should also be present
+	if !strings.Contains(hooksStr, "hookflow run") {
+		t.Error("hookflow hooks should be added")
+	}
+}
+
+// TestRegisterReplacesOldHookflowHooks tests that outdated hookflow hooks are replaced
+func TestRegisterReplacesOldHookflowHooks(t *testing.T) {
+	homeDir := t.TempDir()
+	origHome := overrideHomeDir(t, homeDir)
+	defer restoreHomeDir(origHome)
+
+	// Create existing hooks.json with OLD hookflow hooks (e.g., without --global)
+	hooksDir := filepath.Join(homeDir, ".copilot", "hooks")
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		t.Fatalf("failed to create hooks dir: %v", err)
+	}
+
+	oldConfig := map[string]interface{}{
+		"version": 1,
+		"hooks": map[string]interface{}{
+			"preToolUse": []interface{}{
+				map[string]interface{}{
+					"type": "command",
+					"bash": "gh hookflow run --raw --event-type preToolUse",
+				},
+			},
+			"postToolUse": []interface{}{
+				map[string]interface{}{
+					"type": "command",
+					"bash": "gh hookflow run --raw --event-type postToolUse",
+				},
+			},
+		},
+	}
+	oldJSON, _ := json.MarshalIndent(oldConfig, "", "  ")
+	hooksFile := filepath.Join(hooksDir, "hooks.json")
+	if err := os.WriteFile(hooksFile, oldJSON, 0644); err != nil {
+		t.Fatalf("failed to create hooks.json: %v", err)
+	}
+
+	// Register (should replace old hooks with new ones that have --global)
+	if err := runRegister(false, false, false); err != nil {
+		t.Fatalf("runRegister failed: %v", err)
+	}
+
+	// Read updated hooks.json
+	hooksData, err := os.ReadFile(hooksFile)
+	if err != nil {
+		t.Fatalf("failed to read hooks.json: %v", err)
+	}
+
+	hooksStr := string(hooksData)
+
+	// New hooks should have --global flag
+	if !strings.Contains(hooksStr, "--global") {
+		t.Error("updated hooks should contain --global flag")
+	}
+
+	// Verify no duplicate hookflow hooks
+	var config map[string]interface{}
+	if err := json.Unmarshal(hooksData, &config); err != nil {
+		t.Fatalf("hooks.json is invalid JSON: %v", err)
+	}
+	hooks := config["hooks"].(map[string]interface{})
+
+	preHooks := hooks["preToolUse"].([]interface{})
+	hookflowCount := 0
+	for _, h := range preHooks {
+		hookBytes, _ := json.Marshal(h)
+		if strings.Contains(string(hookBytes), "hookflow") {
+			hookflowCount++
+		}
+	}
+	if hookflowCount != 1 {
+		t.Errorf("expected exactly 1 hookflow preToolUse hook after replacement, got %d", hookflowCount)
+	}
+}
+
+// TestUnregisterRemovesHookflowHooksPreservesOthers tests that unregister only removes hookflow hooks
+func TestUnregisterRemovesHookflowHooksPreservesOthers(t *testing.T) {
+	homeDir := t.TempDir()
+	origHome := overrideHomeDir(t, homeDir)
+	defer restoreHomeDir(origHome)
+
+	// Create hooks.json with both hookflow and custom hooks
+	hooksDir := filepath.Join(homeDir, ".copilot", "hooks")
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		t.Fatalf("failed to create hooks dir: %v", err)
+	}
+
+	config := map[string]interface{}{
+		"version": 1,
+		"hooks": map[string]interface{}{
+			"preToolUse": []interface{}{
+				map[string]interface{}{
+					"type": "command",
+					"bash": "echo 'custom hook'",
+				},
+				map[string]interface{}{
+					"type":       "command",
+					"bash":       "gh hookflow run --raw --event-type preToolUse --global",
+					"powershell": "gh hookflow run --raw --event-type preToolUse --global",
+				},
+			},
+			"postToolUse": []interface{}{
+				map[string]interface{}{
+					"type":       "command",
+					"bash":       "gh hookflow run --raw --event-type postToolUse --global",
+					"powershell": "gh hookflow run --raw --event-type postToolUse --global",
+				},
+			},
+			"sessionStart": []interface{}{
+				map[string]interface{}{
+					"type": "command",
+					"bash": "gh hookflow check-setup",
+				},
+			},
+		},
+	}
+	configJSON, _ := json.MarshalIndent(config, "", "  ")
+	hooksFile := filepath.Join(hooksDir, "hooks.json")
+	if err := os.WriteFile(hooksFile, configJSON, 0644); err != nil {
+		t.Fatalf("failed to create hooks.json: %v", err)
+	}
+
+	// Also create skill
+	skillDir := filepath.Join(homeDir, ".copilot", "skills", "hookflow")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatalf("failed to create skill dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("test"), 0644); err != nil {
+		t.Fatalf("failed to create SKILL.md: %v", err)
+	}
+
+	// Unregister
+	if err := runRegister(true, false, false); err != nil {
+		t.Fatalf("runRegister --unregister failed: %v", err)
+	}
+
+	// Verify hooks.json still exists (has custom hook)
+	hooksData, err := os.ReadFile(hooksFile)
+	if err != nil {
+		t.Fatalf("failed to read hooks.json: %v", err)
+	}
+
+	hooksStr := string(hooksData)
+
+	// Custom hook should be preserved
+	if !strings.Contains(hooksStr, "custom hook") {
+		t.Error("custom hook should be preserved after unregister")
+	}
+
+	// Hookflow hooks should be removed
+	if strings.Contains(hooksStr, "hookflow run") {
+		t.Error("hookflow run hooks should be removed after unregister")
+	}
+	if strings.Contains(hooksStr, "hookflow check-setup") {
+		t.Error("hookflow check-setup hook should be removed after unregister")
+	}
+
+	// Skill directory should be removed
+	skillPath := filepath.Join(homeDir, ".copilot", "skills", "hookflow")
+	if _, err := os.Stat(skillPath); !os.IsNotExist(err) {
+		t.Error("skill directory should be removed after unregister")
+	}
+}
+
+// TestUnregisterRemovesHooksFileWhenEmpty tests that hooks.json is deleted when no hooks remain
+func TestUnregisterRemovesHooksFileWhenEmpty(t *testing.T) {
+	homeDir := t.TempDir()
+	origHome := overrideHomeDir(t, homeDir)
+	defer restoreHomeDir(origHome)
+
+	// Register first
+	if err := runRegister(false, false, false); err != nil {
+		t.Fatalf("runRegister failed: %v", err)
+	}
+
+	// Unregister
+	if err := runRegister(true, false, false); err != nil {
+		t.Fatalf("runRegister --unregister failed: %v", err)
+	}
+
+	// hooks.json should be removed since no hooks remain
+	hooksFile := filepath.Join(homeDir, ".copilot", "hooks", "hooks.json")
+	if _, err := os.Stat(hooksFile); !os.IsNotExist(err) {
+		t.Error("hooks.json should be removed when no hooks remain")
+	}
+}
+
+// TestRegisterHooksOnly tests the --hooks-only flag
+func TestRegisterHooksOnly(t *testing.T) {
+	homeDir := t.TempDir()
+	origHome := overrideHomeDir(t, homeDir)
+	defer restoreHomeDir(origHome)
+
+	if err := runRegister(false, true, false); err != nil {
+		t.Fatalf("runRegister --hooks-only failed: %v", err)
+	}
+
+	// Hooks should exist
+	hooksPath := filepath.Join(homeDir, ".copilot", "hooks", "hooks.json")
+	assertFileExists(t, hooksPath)
+
+	// Skill should NOT exist
+	skillPath := filepath.Join(homeDir, ".copilot", "skills", "hookflow", "SKILL.md")
+	if _, err := os.Stat(skillPath); !os.IsNotExist(err) {
+		t.Error("SKILL.md should not be created with --hooks-only")
+	}
+}
+
+// TestRegisterSkillOnly tests the --skill-only flag
+func TestRegisterSkillOnly(t *testing.T) {
+	homeDir := t.TempDir()
+	origHome := overrideHomeDir(t, homeDir)
+	defer restoreHomeDir(origHome)
+
+	if err := runRegister(false, false, true); err != nil {
+		t.Fatalf("runRegister --skill-only failed: %v", err)
+	}
+
+	// Skill should exist
+	skillPath := filepath.Join(homeDir, ".copilot", "skills", "hookflow", "SKILL.md")
+	assertFileExists(t, skillPath)
+
+	// Hooks should NOT exist
+	hooksPath := filepath.Join(homeDir, ".copilot", "hooks", "hooks.json")
+	if _, err := os.Stat(hooksPath); !os.IsNotExist(err) {
+		t.Error("hooks.json should not be created with --skill-only")
+	}
+}
+
+// TestRegisterHandlesInvalidExistingJSON tests that invalid existing hooks.json is backed up
+func TestRegisterHandlesInvalidExistingJSON(t *testing.T) {
+	homeDir := t.TempDir()
+	origHome := overrideHomeDir(t, homeDir)
+	defer restoreHomeDir(origHome)
+
+	// Create invalid hooks.json
+	hooksDir := filepath.Join(homeDir, ".copilot", "hooks")
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		t.Fatalf("failed to create hooks dir: %v", err)
+	}
+
+	hooksFile := filepath.Join(hooksDir, "hooks.json")
+	if err := os.WriteFile(hooksFile, []byte("not valid json{{{"), 0644); err != nil {
+		t.Fatalf("failed to create invalid hooks.json: %v", err)
+	}
+
+	// Register should succeed (backs up invalid file)
+	if err := runRegister(false, true, false); err != nil {
+		t.Fatalf("runRegister with invalid existing JSON failed: %v", err)
+	}
+
+	// Backup should exist
+	bakFile := hooksFile + ".bak"
+	assertFileExists(t, bakFile)
+
+	// New hooks.json should be valid
+	hooksData, err := os.ReadFile(hooksFile)
+	if err != nil {
+		t.Fatalf("failed to read hooks.json: %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(hooksData, &config); err != nil {
+		t.Fatalf("new hooks.json should be valid JSON: %v", err)
+	}
+}
+
+// TestUnregisterNoExistingFiles tests that unregister handles missing files gracefully
+func TestUnregisterNoExistingFiles(t *testing.T) {
+	homeDir := t.TempDir()
+	origHome := overrideHomeDir(t, homeDir)
+	defer restoreHomeDir(origHome)
+
+	// Unregister when nothing exists should not error
+	if err := runRegister(true, false, false); err != nil {
+		t.Fatalf("runRegister --unregister with no files should not error: %v", err)
+	}
+}
+
+// TestRegisterSessionStartHookContent tests that sessionStart hook references hookflow register
+func TestRegisterSessionStartHookContent(t *testing.T) {
+	homeDir := t.TempDir()
+	origHome := overrideHomeDir(t, homeDir)
+	defer restoreHomeDir(origHome)
+
+	if err := runRegister(false, true, false); err != nil {
+		t.Fatalf("runRegister failed: %v", err)
+	}
+
+	hooksPath := filepath.Join(homeDir, ".copilot", "hooks", "hooks.json")
+	hooksData, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("failed to read hooks.json: %v", err)
+	}
+
+	hooksStr := string(hooksData)
+
+	// sessionStart should reference "hookflow register" not plugin install
+	if !strings.Contains(hooksStr, "hookflow register") {
+		t.Error("sessionStart hook should reference 'hookflow register'")
+	}
+	if strings.Contains(hooksStr, "copilot plugin install") {
+		t.Error("sessionStart hook should NOT reference 'copilot plugin install'")
+	}
+}
+
+// TestRegisterPersonalHooksHaveGlobalFlag tests that personal hooks use --global flag
+func TestRegisterPersonalHooksHaveGlobalFlag(t *testing.T) {
+	homeDir := t.TempDir()
+	origHome := overrideHomeDir(t, homeDir)
+	defer restoreHomeDir(origHome)
+
+	if err := runRegister(false, true, false); err != nil {
+		t.Fatalf("runRegister failed: %v", err)
+	}
+
+	hooksPath := filepath.Join(homeDir, ".copilot", "hooks", "hooks.json")
+	hooksData, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("failed to read hooks.json: %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(hooksData, &config); err != nil {
+		t.Fatalf("hooks.json is invalid JSON: %v", err)
+	}
+
+	hooks := config["hooks"].(map[string]interface{})
+
+	// Check preToolUse has --global in bash and powershell
+	preHooks := hooks["preToolUse"].([]interface{})
+	found := false
+	for _, h := range preHooks {
+		hookMap, ok := h.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		bashCmd, _ := hookMap["bash"].(string)
+		psCmd, _ := hookMap["powershell"].(string)
+		if strings.Contains(bashCmd, "--global") && strings.Contains(psCmd, "--global") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("preToolUse hook should have --global flag in both bash and powershell commands")
+	}
+
+	// Check postToolUse has --global
+	postHooks := hooks["postToolUse"].([]interface{})
+	found = false
+	for _, h := range postHooks {
+		hookMap, ok := h.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		bashCmd, _ := hookMap["bash"].(string)
+		psCmd, _ := hookMap["powershell"].(string)
+		if strings.Contains(bashCmd, "--global") && strings.Contains(psCmd, "--global") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("postToolUse hook should have --global flag in both bash and powershell commands")
+	}
+}
+
+// TestGenerateRegisterSkillMD tests that the generated skill markdown has all required sections
+func TestGenerateRegisterSkillMD(t *testing.T) {
+	content := generateRegisterSkillMD()
+
+	requiredSections := []string{
+		"name: hookflow",
+		"description:",
+		"Quick Reference",
+		"Workflow Schema",
+		"Required Fields",
+		"Optional Fields",
+		"Trigger Types",
+		"File Trigger",
+		"Tool Trigger",
+		"Multiple Tool Triggers",
+		"Commit Trigger",
+		"Push Trigger",
+		"Expression Syntax",
+		"String Functions",
+		"Step Outcome Functions",
+		"Transcript Functions",
+		"Step Configuration",
+		"Reusable Actions",
+		"Common Patterns",
+		"Block Sensitive Files",
+		"Troubleshooting",
+		"hookflow register",
+		"hookflow init",
+		"hookflow validate",
+		"concurrency",
+		"continue-on-error",
+		"transcript_count",
+		"transcript_since",
+		"transcript_last",
+		"success()",
+		"failure()",
+		"always()",
+		"git-push",
+	}
+
+	for _, section := range requiredSections {
+		if !strings.Contains(content, section) {
+			t.Errorf("SKILL.md missing required content: %s", section)
+		}
+	}
+}
+
+// TestUnregisterHooksOnlyPreservesSkill tests that --hooks-only unregister keeps skill
+func TestUnregisterHooksOnlyPreservesSkill(t *testing.T) {
+	homeDir := t.TempDir()
+	origHome := overrideHomeDir(t, homeDir)
+	defer restoreHomeDir(origHome)
+
+	// Register both
+	if err := runRegister(false, false, false); err != nil {
+		t.Fatalf("runRegister failed: %v", err)
+	}
+
+	// Unregister hooks only
+	if err := runRegister(true, true, false); err != nil {
+		t.Fatalf("runRegister --unregister --hooks-only failed: %v", err)
+	}
+
+	// Hooks should be gone
+	hooksFile := filepath.Join(homeDir, ".copilot", "hooks", "hooks.json")
+	if _, err := os.Stat(hooksFile); !os.IsNotExist(err) {
+		t.Error("hooks.json should be removed after --hooks-only unregister")
+	}
+
+	// Skill should still exist
+	skillPath := filepath.Join(homeDir, ".copilot", "skills", "hookflow", "SKILL.md")
+	assertFileExists(t, skillPath)
+}
+
+// TestUnregisterSkillOnlyPreservesHooks tests that --skill-only unregister keeps hooks
+func TestUnregisterSkillOnlyPreservesHooks(t *testing.T) {
+	homeDir := t.TempDir()
+	origHome := overrideHomeDir(t, homeDir)
+	defer restoreHomeDir(origHome)
+
+	// Register both
+	if err := runRegister(false, false, false); err != nil {
+		t.Fatalf("runRegister failed: %v", err)
+	}
+
+	// Unregister skill only
+	if err := runRegister(true, false, true); err != nil {
+		t.Fatalf("runRegister --unregister --skill-only failed: %v", err)
+	}
+
+	// Hooks should still exist
+	hooksFile := filepath.Join(homeDir, ".copilot", "hooks", "hooks.json")
+	assertFileExists(t, hooksFile)
+
+	// Skill should be gone
+	skillPath := filepath.Join(homeDir, ".copilot", "skills", "hookflow", "SKILL.md")
+	if _, err := os.Stat(skillPath); !os.IsNotExist(err) {
+		t.Error("SKILL.md should be removed after --skill-only unregister")
+	}
+}
+
+// TestMergePersonalHooksJSONVersionField tests that version field is preserved
+func TestMergePersonalHooksJSONVersionField(t *testing.T) {
+	homeDir := t.TempDir()
+	origHome := overrideHomeDir(t, homeDir)
+	defer restoreHomeDir(origHome)
+
+	if err := runRegister(false, true, false); err != nil {
+		t.Fatalf("runRegister failed: %v", err)
+	}
+
+	hooksPath := filepath.Join(homeDir, ".copilot", "hooks", "hooks.json")
+	hooksData, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("failed to read hooks.json: %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(hooksData, &config); err != nil {
+		t.Fatalf("hooks.json is invalid JSON: %v", err)
+	}
+
+	version, ok := config["version"]
+	if !ok {
+		t.Error("hooks.json should have version field")
+	}
+	if v, ok := version.(float64); !ok || v != 1 {
+		t.Errorf("hooks.json version should be 1, got %v", version)
+	}
+}
+
+// TestRegisterHooksTimeout tests that hooks have proper timeout values
+func TestRegisterHooksTimeout(t *testing.T) {
+	homeDir := t.TempDir()
+	origHome := overrideHomeDir(t, homeDir)
+	defer restoreHomeDir(origHome)
+
+	if err := runRegister(false, true, false); err != nil {
+		t.Fatalf("runRegister failed: %v", err)
+	}
+
+	hooksPath := filepath.Join(homeDir, ".copilot", "hooks", "hooks.json")
+	hooksData, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("failed to read hooks.json: %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(hooksData, &config); err != nil {
+		t.Fatalf("hooks.json is invalid JSON: %v", err)
+	}
+
+	hooks := config["hooks"].(map[string]interface{})
+
+	for _, hookType := range []string{"preToolUse", "postToolUse", "sessionStart"} {
+		arr := hooks[hookType].([]interface{})
+		for _, h := range arr {
+			hookMap := h.(map[string]interface{})
+			timeout, ok := hookMap["timeoutSec"]
+			if !ok {
+				t.Errorf("%s hook missing timeoutSec", hookType)
+			}
+			if v, ok := timeout.(float64); !ok || v != 1800 {
+				t.Errorf("%s hook timeoutSec should be 1800, got %v", hookType, timeout)
+			}
+		}
+	}
+}
+
+// --- Test Helpers ---
+
+// overrideHomeDir temporarily overrides HOME/USERPROFILE for testing.
+// Returns the original value to restore later.
+func overrideHomeDir(t *testing.T, newHome string) string {
+	t.Helper()
+	origHome := os.Getenv("HOME")
+	origUserProfile := os.Getenv("USERPROFILE")
+
+	t.Setenv("HOME", newHome)
+	t.Setenv("USERPROFILE", newHome)
+
+	// Return original for manual restore if needed
+	if origHome != "" {
+		return origHome
+	}
+	return origUserProfile
+}
+
+// restoreHomeDir is a no-op since t.Setenv automatically restores.
+// Kept for readability in defer statements.
+func restoreHomeDir(_ string) {}
+
+// assertFileExists checks that a file exists at the given path
+func assertFileExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Errorf("expected file to exist: %s", path)
+	}
+}

--- a/packages/npm-wrapper/README.md
+++ b/packages/npm-wrapper/README.md
@@ -27,9 +27,12 @@ curl -sSL https://raw.githubusercontent.com/htekdev/gh-hookflow/main/scripts/ins
 ## Quick Start
 
 ```bash
-# Initialize gh-hookflow in your repo
+# One-time global setup — enables hookflow for all repos
+hookflow register
+
+# Add workflows to a specific repo
 cd your-project
-hookflow init
+hookflow init --repo
 
 # Create a workflow using AI
 hookflow create "block edits to .env files"
@@ -54,12 +57,16 @@ gh-hookflow lets you run "shift-left" DevOps checks during AI agent editing sess
 
 | Command | Description |
 |---------|-------------|
-| `init` | Initialize gh-hookflow for a repository |
+| `register` | Register personal hooks + skill (global, all repos) |
+| `register --unregister` | Remove personal hooks and skill |
+| `init` | Initialize per-repo hooks |
+| `init --repo` | Also scaffold example workflows |
 | `create <prompt>` | Create a workflow using AI |
 | `discover` | List workflows in the current repository |
 | `validate` | Validate workflow YAML files |
 | `test` | Test a workflow with a mock event |
 | `run` | Run workflows (used by hooks) |
+| `git-push` | Push with governance workflows |
 | `logs` | View debug logs |
 | `version` | Show version information |
 


### PR DESCRIPTION
## Summary

Adds a new \hookflow register\ CLI command that replaces plugin-based delivery of personal hooks and the hookflow skill.

## Changes

- **\cmd/hookflow/register.go\** — New \hookflow register\ command
  - Writes hooks to \~/.copilot/hooks/hooks.json\ (with \--global\ flag)
  - Writes comprehensive SKILL.md to \~/.copilot/skills/hookflow/SKILL.md\
  - Supports \--unregister\, \--hooks-only\, \--skill-only\ flags
  - Idempotent: detects and replaces existing hookflow hooks, preserves non-hookflow hooks
  - Handles invalid JSON gracefully (backs up and starts fresh)

- **\cmd/hookflow/register_test.go\** — 17 tests covering:
  - Happy path, idempotency, merge preservation
  - Hook replacement, unregistration, flag combinations
  - Invalid JSON handling, content validation, timeout values

- **\cmd/hookflow/init.go\** — Updated messaging to reference \hookflow register\ instead of plugin install

- **Updated SKILL.md content** — Now covers transcript functions, concurrency, continue-on-error, step outcomes, multiple tool triggers, push triggers, and the register/init workflow

## Usage

\\\ash
# Register personal hooks + skill
hookflow register

# Only hooks
hookflow register --hooks-only

# Only skill
hookflow register --skill-only

# Remove everything
hookflow register --unregister
\\\

## Testing

All 26 tests pass (17 new + 9 existing init tests).