### PR TITLE
fix: filter non-hookify .md files in discover and use path-agnostic glob for tool args

### DIFF
--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -45,6 +45,13 @@ func Discover(rootDir string) ([]WorkflowFile, error) {
 			return nil
 		}
 
+		// For .md files, verify they have YAML frontmatter (hookify format)
+		if ext == ".md" {
+			if !hasYAMLFrontmatter(path) {
+				return nil
+			}
+		}
+
 		// Get relative path
 		relPath, err := filepath.Rel(rootDir, path)
 		if err != nil {
@@ -91,6 +98,13 @@ func DiscoverByGlob(rootDir string, pattern string) ([]WorkflowFile, error) {
 			continue
 		}
 
+		// For .md files, verify they have YAML frontmatter (hookify format)
+		if ext == ".md" {
+			if !hasYAMLFrontmatter(path) {
+				continue
+			}
+		}
+
 		relPath, err := filepath.Rel(rootDir, path)
 		if err != nil {
 			relPath = path
@@ -117,4 +131,16 @@ func Exists(rootDir, workflowName string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// hasYAMLFrontmatter checks if a file starts with YAML frontmatter delimiter (---).
+// This is a lightweight check to distinguish hookify-format markdown files from
+// plain markdown (e.g., README.md) without doing a full parse.
+func hasYAMLFrontmatter(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	content := strings.TrimSpace(string(data))
+	return strings.HasPrefix(content, "---")
 }

--- a/internal/discover/discover_test.go
+++ b/internal/discover/discover_test.go
@@ -3,6 +3,7 @@ package discover
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -376,7 +377,12 @@ func TestDiscoverNonStandardExtensions(t *testing.T) {
 	}
 
 	for f := range files {
-		if err := os.WriteFile(filepath.Join(workflowDir, f), []byte("content"), 0644); err != nil {
+		content := "content"
+		// .md files need YAML frontmatter to be recognized as hookify rules
+		if strings.ToLower(filepath.Ext(f)) == ".md" {
+			content = "---\nname: test\nevent: file\naction: warn\n---\nTest rule"
+		}
+		if err := os.WriteFile(filepath.Join(workflowDir, f), []byte(content), 0644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -674,5 +680,87 @@ func TestWorkflowFileNameExtraction(t *testing.T) {
 		if !discovered[expected] {
 			t.Errorf("Expected workflow name %q not found", expected)
 		}
+	}
+}
+
+func TestDiscoverSkipsMdWithoutFrontmatter(t *testing.T) {
+	tmpDir := t.TempDir()
+	workflowDir := filepath.Join(tmpDir, ".github", "hookflows")
+	if err := os.MkdirAll(workflowDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a valid YAML workflow
+	if err := os.WriteFile(filepath.Join(workflowDir, "lint.yml"), []byte("name: lint"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a plain markdown file (no YAML frontmatter) — should be skipped
+	if err := os.WriteFile(filepath.Join(workflowDir, "README.md"), []byte("# Notes\nThis is not a workflow."), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a valid hookify markdown file (with YAML frontmatter) — should be found
+	hookifyContent := "---\nname: block-secrets\nevent: file\naction: block\n---\nDo not commit secrets."
+	if err := os.WriteFile(filepath.Join(workflowDir, "block-secrets.md"), []byte(hookifyContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	workflows, err := Discover(tmpDir)
+	if err != nil {
+		t.Fatalf("Discover() error = %v", err)
+	}
+
+	if len(workflows) != 2 {
+		t.Errorf("Discover() found %d workflows, want 2 (lint.yml + block-secrets.md)", len(workflows))
+		for _, w := range workflows {
+			t.Logf("  found: %s (%s)", w.Name, w.RelPath)
+		}
+	}
+
+	names := make(map[string]bool)
+	for _, w := range workflows {
+		names[w.Name] = true
+	}
+
+	if !names["lint"] {
+		t.Error("Expected to find 'lint' workflow")
+	}
+	if !names["block-secrets"] {
+		t.Error("Expected to find 'block-secrets' hookify workflow")
+	}
+	if names["README"] {
+		t.Error("README.md should not be discovered as a workflow")
+	}
+}
+
+func TestDiscoverByGlobSkipsMdWithoutFrontmatter(t *testing.T) {
+	tmpDir := t.TempDir()
+	workflowDir := filepath.Join(tmpDir, ".github", "hookflows")
+	if err := os.MkdirAll(workflowDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Plain markdown — no frontmatter
+	if err := os.WriteFile(filepath.Join(workflowDir, "notes.md"), []byte("# Notes"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Valid hookify markdown
+	hookifyContent := "---\nname: test-rule\nevent: bash\naction: warn\n---\nWarning message."
+	if err := os.WriteFile(filepath.Join(workflowDir, "test-rule.md"), []byte(hookifyContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	workflows, err := DiscoverByGlob(tmpDir, "*.md")
+	if err != nil {
+		t.Fatalf("DiscoverByGlob() error = %v", err)
+	}
+
+	if len(workflows) != 1 {
+		t.Errorf("DiscoverByGlob(*.md) found %d workflows, want 1", len(workflows))
+	}
+	if len(workflows) > 0 && workflows[0].Name != "test-rule" {
+		t.Errorf("Expected 'test-rule', got %q", workflows[0].Name)
 	}
 }

--- a/internal/trigger/matcher.go
+++ b/internal/trigger/matcher.go
@@ -110,7 +110,7 @@ func (m *Matcher) matchToolTrigger(trigger *schema.ToolTrigger, event *schema.To
 			return false
 		}
 		argStr, _ := argValue.(string)
-		if !matchGlob(pattern, argStr) {
+		if !matchPlainGlob(pattern, argStr) {
 			return false
 		}
 	}
@@ -327,7 +327,7 @@ func (m *Matcher) matchPushTrigger(trigger *schema.PushTrigger, event *schema.Pu
 	return true
 }
 
-// matchGlob performs glob pattern matching
+// matchGlob performs glob pattern matching for file paths
 func matchGlob(pattern, path string) bool {
 	// Normalize path separators
 	pattern = filepath.ToSlash(pattern)
@@ -340,6 +340,24 @@ func matchGlob(pattern, path string) bool {
 
 	// Use filepath.Match for simple patterns
 	matched, _ := filepath.Match(pattern, path)
+	return matched
+}
+
+// matchPlainGlob performs glob matching without path separator semantics.
+// Unlike matchGlob, the * wildcard matches any character including / and \.
+// Use this for non-path values like shell commands and tool arguments where
+// forward slashes are not directory separators.
+func matchPlainGlob(pattern, value string) bool {
+	// filepath.Match treats os.PathSeparator as special — * won't match it.
+	// On Linux, / is the separator, so *rm* won't match "rm -rf /important".
+	// To do path-agnostic matching, replace both / and \ with a character
+	// that is never a path separator on any OS.
+	const safeChar = "\x01"
+	p := strings.ReplaceAll(pattern, "/", safeChar)
+	p = strings.ReplaceAll(p, "\\", safeChar)
+	v := strings.ReplaceAll(value, "/", safeChar)
+	v = strings.ReplaceAll(v, "\\", safeChar)
+	matched, _ := filepath.Match(p, v)
 	return matched
 }
 

--- a/internal/trigger/matcher_test.go
+++ b/internal/trigger/matcher_test.go
@@ -1172,3 +1172,119 @@ func TestPushTriggerBranchesIgnoreWithNoMatchingBranch(t *testing.T) {
 		t.Error("Expected non-ignored branch to match")
 	}
 }
+
+func TestMatchPlainGlob(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		value   string
+		want    bool
+	}{
+		{
+			name:    "simple wildcard match",
+			pattern: "*rm*",
+			value:   "rm -rf /important",
+			want:    true,
+		},
+		{
+			name:    "wildcard with forward slashes in value",
+			pattern: "*test*",
+			value:   "test /path/to/file",
+			want:    true,
+		},
+		{
+			name:    "exact match",
+			pattern: "hello",
+			value:   "hello",
+			want:    true,
+		},
+		{
+			name:    "no match",
+			pattern: "*foo*",
+			value:   "bar baz",
+			want:    false,
+		},
+		{
+			name:    "wildcard prefix",
+			pattern: "*.json",
+			value:   "config.json",
+			want:    true,
+		},
+		{
+			name:    "wildcard suffix",
+			pattern: "rm*",
+			value:   "rm -rf /tmp/data",
+			want:    true,
+		},
+		{
+			name:    "question mark wildcard",
+			pattern: "t?st",
+			value:   "test",
+			want:    true,
+		},
+		{
+			name:    "backslash in value",
+			pattern: "*file*",
+			value:   "C:\\Users\\file.txt",
+			want:    true,
+		},
+		{
+			name:    "empty pattern and value",
+			pattern: "",
+			value:   "",
+			want:    true,
+		},
+		{
+			name:    "empty pattern nonempty value",
+			pattern: "",
+			value:   "something",
+			want:    false,
+		},
+		{
+			name:    "mixed slashes",
+			pattern: "*important*",
+			value:   "rm -rf /path\\to/important",
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchPlainGlob(tt.pattern, tt.value)
+			if got != tt.want {
+				t.Errorf("matchPlainGlob(%q, %q) = %v, want %v", tt.pattern, tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchToolTriggerWithSlashesInArgs(t *testing.T) {
+	// Regression test: tool arg patterns must match values containing /
+	// This failed on Linux because filepath.Match treats * as not matching /
+	workflow := &schema.Workflow{
+		Name: "test-shell-command",
+		On: schema.OnConfig{
+			Tool: &schema.ToolTrigger{
+				Name: "powershell",
+				Args: map[string]string{
+					"command": "*rm*",
+				},
+			},
+		},
+	}
+
+	matcher := NewMatcher(workflow)
+
+	event := &schema.Event{
+		Tool: &schema.ToolEvent{
+			Name: "powershell",
+			Args: map[string]interface{}{
+				"command": "rm -rf /important",
+			},
+		},
+	}
+
+	if !matcher.Match(event) {
+		t.Error("Expected tool trigger to match command containing forward slashes")
+	}
+}


### PR DESCRIPTION
## Problem

Two tests fail on Linux CI but pass on Windows, blocking the auto-release workflow (run 23021607648):

1. **TestDiscoverSkipsNonYaml** — `discover.Discover()` picks up `README.md` as a workflow because PR #16 added `.md` as a valid extension for hookify rules, but without validation to distinguish real hookify `.md` files from plain markdown.

2. **TestToolTriggerShellCommand** — `matchGlob` uses `filepath.Match` where `*` doesn't match `/` (the path separator on Linux). The command `rm -rf /important` contains `/`, so pattern `*rm*` fails on Linux. On Windows, `\` is the path separator so `/` is just a regular character.

Both are **real code bugs** introduced by the hookify format PR (#16), not test issues.

## Fixes

### Fix 1: `internal/discover/discover.go` — Filter non-hookify `.md` files

Added `hasYAMLFrontmatter()` that reads a `.md` file and checks for `---` prefix. Both `Discover()` and `DiscoverByGlob()` now skip `.md` files without frontmatter.

### Fix 2: `internal/trigger/matcher.go` — Path-agnostic glob for tool args

Added `matchPlainGlob()` that replaces both `/` and `\` with a safe character before calling `filepath.Match`, so glob `*` matches across slashes. Used only in `matchToolTrigger` for arg value matching — file path matching still uses the path-separator-aware `matchGlob`.

## Tests Added

- `TestDiscoverSkipsMdWithoutFrontmatter` — verifies `.md` without frontmatter is skipped
- `TestDiscoverByGlobSkipsMdWithoutFrontmatter` — same for glob-based discovery
- `TestMatchPlainGlob` — 11 subtests covering slashes, backslashes, mixed paths, empty strings
- `TestMatchToolTriggerWithSlashesInArgs` — regression test for the exact failing scenario