### PR TITLE
feat: support all 13 Copilot CLI hook events + new action types

### DIFF
--- a/cmd/hookflow/cmd_test.go
+++ b/cmd/hookflow/cmd_test.go
@@ -4183,7 +4183,7 @@ stdoutR, stdoutW, _ := os.Pipe()
 os.Stdout = stdoutW
 
 escapedDir := strings.ReplaceAll(tmpDir, `\`, `\\`)
-_ = runWithRawInput(tmpDir, `{"toolName":"create","toolArgs":{"path":"test.txt","file_text":"hello"},"cwd":"`+escapedDir+`"}`, "pre", true)
+_ = runWithRawInput(tmpDir, `{"toolName":"create","toolArgs":{"path":"test.txt","file_text":"hello"},"cwd":"`+escapedDir+`"}`, "pre", "", true)
 
 _ = stdoutW.Close()
 os.Stdout = oldStdout
@@ -4233,7 +4233,7 @@ stdoutR, stdoutW, _ := os.Pipe()
 os.Stdout = stdoutW
 
 escapedDir := strings.ReplaceAll(tmpDir, `\`, `\\`)
-_ = runWithRawInput(tmpDir, `{"toolName":"create","toolArgs":{"path":"test.txt","file_text":"hello"},"cwd":"`+escapedDir+`"}`, "pre", true)
+_ = runWithRawInput(tmpDir, `{"toolName":"create","toolArgs":{"path":"test.txt","file_text":"hello"},"cwd":"`+escapedDir+`"}`, "pre", "", true)
 
 _ = stdoutW.Close()
 os.Stdout = oldStdout
@@ -4281,7 +4281,7 @@ stdoutR, stdoutW, _ := os.Pipe()
 os.Stdout = stdoutW
 
 escapedDir := strings.ReplaceAll(tmpDir, `\`, `\\`)
-_ = runWithRawInput(tmpDir, `{"toolName":"create","toolArgs":{"path":"test.txt","file_text":"hello"},"cwd":"`+escapedDir+`"}`, "pre", true)
+_ = runWithRawInput(tmpDir, `{"toolName":"create","toolArgs":{"path":"test.txt","file_text":"hello"},"cwd":"`+escapedDir+`"}`, "pre", "", true)
 
 _ = stdoutW.Close()
 os.Stdout = oldStdout
@@ -4522,7 +4522,7 @@ os.Stdout = stdoutW
 
 // Pass processCwd as dir (simulating os.Getwd() from plugin context)
 // but hook input cwd is repoDir (the actual repo root)
-_ = runWithRawInput(processCwd, `{"toolName":"create","toolArgs":{"path":"test.txt","file_text":"hello"},"cwd":"`+escapedRepoDir+`"}`, "pre", true)
+_ = runWithRawInput(processCwd, `{"toolName":"create","toolArgs":{"path":"test.txt","file_text":"hello"},"cwd":"`+escapedRepoDir+`"}`, "pre", "", true)
 
 _ = stdoutW.Close()
 os.Stdout = oldStdout
@@ -4707,7 +4707,7 @@ func TestComplianceExemptionWithStringToolArgs(t *testing.T) {
 	stdoutR, stdoutW, _ := os.Pipe()
 	os.Stdout = stdoutW
 
-	_ = runWithRawInput(tmpDir, stringToolArgsInput, "pre", true)
+	_ = runWithRawInput(tmpDir, stringToolArgsInput, "pre", "", true)
 
 	_ = stdoutW.Close()
 	os.Stdout = oldStdout
@@ -5356,7 +5356,7 @@ func TestTranscriptRecording_AppendsOnRawInput(t *testing.T) {
 	stdoutR, stdoutW, _ := os.Pipe()
 	os.Stdout = stdoutW
 
-	_ = runWithRawInput(tmpDir, rawInput, "pre", false)
+	_ = runWithRawInput(tmpDir, rawInput, "pre", "", false)
 
 	_ = stdoutW.Close()
 	os.Stdout = oldStdout

--- a/cmd/hookflow/main.go
+++ b/cmd/hookflow/main.go
@@ -277,7 +277,7 @@ Use --event to pass a pre-built event JSON (legacy mode).`,
 
 		// If --raw flag is set, use the new event detection
 		if raw {
-			return runWithRawInput(dir, eventStr, lifecycle, global)
+			return runWithRawInput(dir, eventStr, lifecycle, eventType, global)
 		}
 
 		// Legacy mode: pre-built event JSON
@@ -290,11 +290,23 @@ var triggersCmd = &cobra.Command{
 	Short: "List available trigger types",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Available trigger types:")
-		fmt.Println("  hooks    - Agent hook events (preToolUse, postToolUse)")
+		fmt.Println("  hooks    - Agent hook events (all 13 Copilot CLI events)")
+		fmt.Println("             preToolUse, postToolUse, postToolUseFailure,")
+		fmt.Println("             sessionStart, sessionEnd, agentStop,")
+		fmt.Println("             subagentStart, subagentStop, permissionRequest,")
+		fmt.Println("             notification, preCompact, errorOccurred,")
+		fmt.Println("             userPromptSubmitted")
 		fmt.Println("  tool     - Tool-specific triggers with argument filtering")
 		fmt.Println("  file     - File create/edit events")
 		fmt.Println("  commit   - Git commit events")
 		fmt.Println("  push     - Git push events")
+		fmt.Println()
+		fmt.Println("Hookify aliases (for .md rules):")
+		fmt.Println("  bash     - Shell tool events (powershell, bash, shell, terminal)")
+		fmt.Println("  file     - File tool events (create, edit)")
+		fmt.Println("  all      - Matches any event type")
+		fmt.Println("  stop     - agentStop and subagentStop events")
+		fmt.Println("  prompt   - userPromptSubmitted events")
 	},
 }
 
@@ -320,7 +332,7 @@ func init() {
 	runCmd.Flags().StringP("workflow", "w", "", "Specific workflow to run")
 	runCmd.Flags().StringP("dir", "d", "", "Directory to search (default: current directory)")
 	runCmd.Flags().BoolP("raw", "r", false, "Accept raw hook input and auto-detect event type")
-	runCmd.Flags().StringP("event-type", "t", "preToolUse", "Hook event type: preToolUse or postToolUse")
+	runCmd.Flags().StringP("event-type", "t", "preToolUse", "Hook event type (preToolUse, postToolUse, postToolUseFailure, sessionStart, sessionEnd, agentStop, subagentStart, subagentStop, permissionRequest, notification, preCompact, errorOccurred, userPromptSubmitted)")
 	runCmd.Flags().Bool("global", false, "Running from global/plugin hooks (skips if repo hooks already ran)")
 
 	// logs flags
@@ -329,13 +341,17 @@ func init() {
 	logsCmd.Flags().Bool("path", false, "Only print log path (for scripting)")
 }
 
-// eventTypeToLifecycle converts Copilot hook event type to workflow lifecycle
+// eventTypeToLifecycle converts Copilot hook event type to workflow lifecycle.
+// All 13 Copilot CLI hook events map to either "pre" or "post":
+//   - preToolUse, sessionStart, subagentStart, permissionRequest, preCompact,
+//     agentStop, userPromptSubmitted, notification, errorOccurred → "pre"
+//   - postToolUse, postToolUseFailure, sessionEnd, subagentStop → "post"
 func eventTypeToLifecycle(eventType string) string {
 	switch eventType {
-	case "postToolUse", "post":
+	case "postToolUse", "postToolUseFailure", "sessionEnd", "subagentStop", "post":
 		return "post"
 	default:
-		return "pre" // preToolUse, pre, or any unknown defaults to pre
+		return "pre"
 	}
 }
 
@@ -363,7 +379,7 @@ func runWorkflow(dir, workflowName string) error {
 }
 
 // runWithRawInput handles raw Copilot hook input and auto-detects event type
-func runWithRawInput(dir, inputStr, lifecycle string, global bool) error {
+func runWithRawInput(dir, inputStr, lifecycle, hookEventType string, global bool) error {
 	log := logging.Context("run")
 	done := logging.StartOperation("runWithRawInput", "dir="+dir, "lifecycle="+lifecycle, fmt.Sprintf("global=%v", global))
 
@@ -508,13 +524,17 @@ func runWithRawInput(dir, inputStr, lifecycle string, global bool) error {
 	// Set lifecycle from CLI flag
 	evt.Lifecycle = lifecycle
 
-	// Populate Hook event — every raw hook invocation is a hook event
-	hookType := "preToolUse"
-	if lifecycle == "post" {
-		hookType = "postToolUse"
+	// Populate Hook event — every raw hook invocation is a hook event.
+	// Use the actual event type from the --event-type flag (not just pre/post lifecycle).
+	if hookEventType == "" {
+		// Fall back to lifecycle-based inference for backward compatibility
+		hookEventType = "preToolUse"
+		if lifecycle == "post" {
+			hookEventType = "postToolUse"
+		}
 	}
 	evt.Hook = &schema.HookEvent{
-		Type: hookType,
+		Type: hookEventType,
 		Cwd:  evt.Cwd,
 	}
 	if evt.Tool != nil {
@@ -528,6 +548,31 @@ func runWithRawInput(dir, inputStr, lifecycle string, global bool) error {
 			Name: raw.ToolName,
 			Args: toolArgs,
 		}
+	}
+
+	// For non-tool events, store the full payload for field extraction
+	switch hookEventType {
+	case "sessionStart", "sessionEnd", "agentStop", "subagentStart", "subagentStop",
+		"permissionRequest", "notification", "preCompact", "errorOccurred", "userPromptSubmitted":
+		var payload map[string]interface{}
+		if err := json.Unmarshal(input, &payload); err == nil {
+			evt.Hook.Payload = payload
+		}
+		// Also populate Tool with the payload data for field extraction compatibility
+		if evt.Tool == nil {
+			evt.Tool = &schema.ToolEvent{
+				Name: hookEventType,
+				Args: make(map[string]interface{}),
+			}
+			if err := json.Unmarshal(input, &evt.Tool.Args); err != nil {
+				evt.Tool.Args = make(map[string]interface{})
+			}
+		}
+	}
+
+	// Store session ID on the event
+	if raw.SessionID != "" {
+		evt.SessionID = raw.SessionID
 	}
 
 	log.Debug("detected event: file=%v, tool=%v, commit=%v, push=%v, hook=%v, lifecycle=%s", evt.File != nil, evt.Tool != nil, evt.Commit != nil, evt.Push != nil, evt.Hook != nil, lifecycle)
@@ -847,16 +892,25 @@ func runMatchingWorkflowsWithEvent(dir string, evt *schema.Event, global bool) e
 	// Aggregate results — deny wins across both hookify and YAML workflows
 	var finalResult *schema.WorkflowResult
 	var warnReasons []string
+	var additionalContexts []string
 
 	// Check hookify results first (already evaluated — pure Go, no shell)
 	for _, result := range hookifyResults {
 		if result.PermissionDecision == "deny" {
-			log.Warn("hookify rule denied: %s", result.PermissionDecisionReason)
+			// ContinueAgent is a special deny that forces agent continuation (agentStop override)
+			if result.ContinueAgent {
+				log.Info("hookify rule forcing agent continuation: %s", result.PermissionDecisionReason)
+			} else {
+				log.Warn("hookify rule denied: %s", result.PermissionDecisionReason)
+			}
 			return outputWorkflowResult(result)
 		}
 		log.Debug("hookify rule allowed/warned")
 		if result.PermissionDecisionReason != "" {
 			warnReasons = append(warnReasons, result.PermissionDecisionReason)
+		}
+		if result.AdditionalContext != "" {
+			additionalContexts = append(additionalContexts, result.AdditionalContext)
 		}
 		finalResult = result
 	}
@@ -892,6 +946,11 @@ func runMatchingWorkflowsWithEvent(dir string, evt *schema.Event, global bool) e
 	// Concatenate all warn reasons so no advisory feedback is lost
 	if len(warnReasons) > 1 && finalResult != nil {
 		finalResult.PermissionDecisionReason = strings.Join(warnReasons, "\n")
+	}
+
+	// Merge all additionalContext from inject rules
+	if len(additionalContexts) > 0 && finalResult != nil {
+		finalResult.AdditionalContext = strings.Join(additionalContexts, "\n\n")
 	}
 
 	return outputWorkflowResult(finalResult)

--- a/internal/ai/ai_test.go
+++ b/internal/ai/ai_test.go
@@ -13,12 +13,13 @@ func TestNewClient(t *testing.T) {
 	c := NewClient()
 	if c == nil {
 		t.Fatal("NewClient returned nil")
-	}
-	if c.started {
-		t.Error("new client should not be started")
-	}
-	if c.client != nil {
-		t.Error("new client should have nil underlying client")
+	} else {
+		if c.started {
+			t.Error("new client should not be started")
+		}
+		if c.client != nil {
+			t.Error("new client should have nil underlying client")
+		}
 	}
 }
 

--- a/internal/hookify/evaluator.go
+++ b/internal/hookify/evaluator.go
@@ -43,28 +43,33 @@ func Evaluate(rule *Rule, event *schema.Event, sessionDir string) *schema.Workfl
 		}
 	case ActionInject:
 		// Inject additionalContext into the hook response.
+		// The markdown body IS the content to inject as context.
 		// Used for subagentStart, notification, sessionStart to provide
 		// governance instructions or context to the agent.
 		return &schema.WorkflowResult{
 			PermissionDecision:       "allow",
-			PermissionDecisionReason: reason,
+			PermissionDecisionReason: fmt.Sprintf("Hookify rule %q injected context", rule.Name),
 			AdditionalContext:        reason,
 		}
 	case ActionModify:
-		// Modify tool args. The message body contains the modification instructions.
-		// For preToolUse, this allows rewriting tool arguments.
+		// Modify tool args. The message body contains the modification content.
+		// ModifyTarget specifies which argument to modify.
+		// ModifyStrategy specifies how: prepend, append, replace, regex.
+		modifiedArgs := applyModify(rule, event)
 		return &schema.WorkflowResult{
 			PermissionDecision:       "allow",
-			PermissionDecisionReason: reason,
-			AdditionalContext:        reason,
+			PermissionDecisionReason: fmt.Sprintf("Hookify rule %q modified arg %q", rule.Name, rule.ModifyTarget),
+			ModifiedArgs:             modifiedArgs,
 		}
 	case ActionContinue:
 		// Force the agent to continue instead of stopping.
+		// The markdown body IS the prompt to respond with when continuing.
 		// Used for agentStop to override the stop decision.
 		return &schema.WorkflowResult{
 			PermissionDecision:       "deny",
-			PermissionDecisionReason: reason,
-			ContinueAgent:           true,
+			PermissionDecisionReason: fmt.Sprintf("Hookify rule %q forced continuation", rule.Name),
+			ContinueAgent:            true,
+			ContinuePrompt:           reason,
 		}
 	default:
 		// Default to warn
@@ -353,3 +358,72 @@ func regexMatch(pattern, value string) bool {
 	}
 	return re.MatchString(value)
 }
+
+// applyModify applies the modify action to the event's tool args.
+// It reads the target arg from the event, applies the strategy using
+// the rule's message body as the modification content, and returns
+// the full modified args map.
+func applyModify(rule *Rule, event *schema.Event) map[string]interface{} {
+	args := getToolArgs(event)
+	if args == nil {
+		args = map[string]interface{}{}
+	}
+
+	// Copy args to avoid mutating the original
+	result := make(map[string]interface{}, len(args))
+	for k, v := range args {
+		result[k] = v
+	}
+
+	target := rule.ModifyTarget
+	content := rule.Message
+	strategy := rule.ModifyStrategy
+
+	// Get current value of the target arg (empty string if not present)
+	currentVal := ""
+	if v, ok := result[target]; ok {
+		if s, ok := v.(string); ok {
+			currentVal = s
+		}
+	}
+
+	var newVal string
+	switch strategy {
+	case StrategyPrepend:
+		newVal = content + currentVal
+	case StrategyAppend:
+		newVal = currentVal + content
+	case StrategyReplace:
+		newVal = content
+	case StrategyRegex:
+		// For regex strategy, the content is in format: /pattern/replacement/
+		// Or simply treated as a replacement for the full value if no regex delimiters
+		newVal = applyRegexStrategy(currentVal, content)
+	default:
+		newVal = content
+	}
+
+	result[target] = newVal
+	return result
+}
+
+// applyRegexStrategy applies a regex substitution.
+// Content format: s/pattern/replacement/ (sed-style) or just replacement text.
+func applyRegexStrategy(currentVal, content string) string {
+	// Try sed-style: s/pattern/replacement/
+	if len(content) > 2 && content[0] == 's' && content[1] == '/' {
+		parts := strings.SplitN(content[2:], "/", 3)
+		if len(parts) >= 2 {
+			pattern := parts[0]
+			replacement := parts[1]
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				return currentVal // invalid regex, return unchanged
+			}
+			return re.ReplaceAllString(currentVal, replacement)
+		}
+	}
+	// Fallback: treat content as full replacement
+	return content
+}
+

--- a/internal/hookify/evaluator.go
+++ b/internal/hookify/evaluator.go
@@ -1,6 +1,7 @@
 package hookify
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -40,6 +41,31 @@ func Evaluate(rule *Rule, event *schema.Event, sessionDir string) *schema.Workfl
 			PermissionDecision:       "allow",
 			PermissionDecisionReason: reason,
 		}
+	case ActionInject:
+		// Inject additionalContext into the hook response.
+		// Used for subagentStart, notification, sessionStart to provide
+		// governance instructions or context to the agent.
+		return &schema.WorkflowResult{
+			PermissionDecision:       "allow",
+			PermissionDecisionReason: reason,
+			AdditionalContext:        reason,
+		}
+	case ActionModify:
+		// Modify tool args. The message body contains the modification instructions.
+		// For preToolUse, this allows rewriting tool arguments.
+		return &schema.WorkflowResult{
+			PermissionDecision:       "allow",
+			PermissionDecisionReason: reason,
+			AdditionalContext:        reason,
+		}
+	case ActionContinue:
+		// Force the agent to continue instead of stopping.
+		// Used for agentStop to override the stop decision.
+		return &schema.WorkflowResult{
+			PermissionDecision:       "deny",
+			PermissionDecisionReason: reason,
+			ContinueAgent:           true,
+		}
 	default:
 		// Default to warn
 		return &schema.WorkflowResult{
@@ -64,6 +90,22 @@ func extractField(field string, event *schema.Event, sessionDir string) string {
 		return extractContent(event)
 	case FieldTranscript:
 		return readTranscriptContent(sessionDir)
+	case FieldToolName:
+		return extractToolName(event)
+	case FieldToolArgs:
+		return extractToolArgsJSON(event)
+	case FieldAgentName:
+		return extractAgentName(event)
+	case FieldAgentType:
+		return extractAgentType(event)
+	case FieldMessage:
+		return extractMessage(event)
+	case FieldHookEvent:
+		return extractHookEventType(event)
+	case FieldSessionID:
+		return extractSessionID(event)
+	case FieldToolResult:
+		return extractToolResult(event)
 	default:
 		return ""
 	}
@@ -156,6 +198,131 @@ func readTranscriptContent(sessionDir string) string {
 		return ""
 	}
 	return string(data)
+}
+
+// extractToolName returns the tool name from the event.
+func extractToolName(event *schema.Event) string {
+	if event.Tool != nil {
+		return event.Tool.Name
+	}
+	if event.Hook != nil && event.Hook.Tool != nil {
+		return event.Hook.Tool.Name
+	}
+	return ""
+}
+
+// extractToolArgsJSON returns all tool args as a JSON string for regex matching.
+func extractToolArgsJSON(event *schema.Event) string {
+	args := getToolArgs(event)
+	if args == nil || len(args) == 0 {
+		return ""
+	}
+	data, err := json.Marshal(args)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+// extractAgentName extracts the agent name from subagentStart/subagentStop events.
+func extractAgentName(event *schema.Event) string {
+	args := getToolArgs(event)
+	if args == nil {
+		return ""
+	}
+	// subagentStart sends agentName in the hook payload
+	if v, ok := args["agentName"]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	if v, ok := args["agent_name"]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// extractAgentType extracts the agent type from subagentStart events.
+func extractAgentType(event *schema.Event) string {
+	args := getToolArgs(event)
+	if args == nil {
+		return ""
+	}
+	if v, ok := args["agentType"]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	if v, ok := args["agent_type"]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// extractMessage extracts the message from notification or error events.
+func extractMessage(event *schema.Event) string {
+	args := getToolArgs(event)
+	if args == nil {
+		return ""
+	}
+	for _, key := range []string{"message", "error", "errorMessage", "description"} {
+		if v, ok := args[key]; ok {
+			if s, ok := v.(string); ok {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// extractHookEventType returns the Copilot CLI hook event type (e.g., "preToolUse").
+func extractHookEventType(event *schema.Event) string {
+	if event.Hook != nil {
+		return event.Hook.Type
+	}
+	return ""
+}
+
+// extractSessionID returns the session identifier from the event.
+func extractSessionID(event *schema.Event) string {
+	if event.SessionID != "" {
+		return event.SessionID
+	}
+	return ""
+}
+
+// extractToolResult extracts the tool result content for postToolUse events.
+func extractToolResult(event *schema.Event) string {
+	args := getToolArgs(event)
+	if args == nil {
+		return ""
+	}
+	if v, ok := args["toolResult"]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+		// toolResult might be a nested object — marshal to JSON
+		data, err := json.Marshal(v)
+		if err == nil {
+			return string(data)
+		}
+	}
+	return ""
+}
+
+// getToolArgs returns tool args, checking both Tool and Hook.Tool.
+func getToolArgs(event *schema.Event) map[string]interface{} {
+	if event.Tool != nil && event.Tool.Args != nil {
+		return event.Tool.Args
+	}
+	if event.Hook != nil && event.Hook.Tool != nil && event.Hook.Tool.Args != nil {
+		return event.Hook.Tool.Args
+	}
+	return nil
 }
 
 // evaluateCondition applies the operator to check if fieldValue matches the pattern.

--- a/internal/hookify/evaluator.go
+++ b/internal/hookify/evaluator.go
@@ -219,7 +219,7 @@ func extractToolName(event *schema.Event) string {
 // extractToolArgsJSON returns all tool args as a JSON string for regex matching.
 func extractToolArgsJSON(event *schema.Event) string {
 	args := getToolArgs(event)
-	if args == nil || len(args) == 0 {
+	if len(args) == 0 {
 		return ""
 	}
 	data, err := json.Marshal(args)

--- a/internal/hookify/evaluator_test.go
+++ b/internal/hookify/evaluator_test.go
@@ -8,6 +8,14 @@ import (
 	"github.com/htekdev/gh-hookflow/internal/schema"
 )
 
+func requireWorkflowResult(t *testing.T, result *schema.WorkflowResult, message string) *schema.WorkflowResult {
+	t.Helper()
+	if result == nil {
+		t.Fatal(message)
+	}
+	return result
+}
+
 // --- Operator tests ---
 
 func TestEvaluateCondition_RegexMatch(t *testing.T) {
@@ -483,12 +491,13 @@ func TestEvaluate_BlockAction(t *testing.T) {
 	result := Evaluate(rule, event, "")
 	if result == nil {
 		t.Fatal("expected non-nil result for matching block rule")
-	}
-	if result.PermissionDecision != "deny" {
-		t.Errorf("expected deny, got %q", result.PermissionDecision)
-	}
-	if result.PermissionDecisionReason != "⚠️ Dangerous command blocked" {
-		t.Errorf("unexpected reason: %q", result.PermissionDecisionReason)
+	} else {
+		if result.PermissionDecision != "deny" {
+			t.Errorf("expected deny, got %q", result.PermissionDecision)
+		}
+		if result.PermissionDecisionReason != "⚠️ Dangerous command blocked" {
+			t.Errorf("unexpected reason: %q", result.PermissionDecisionReason)
+		}
 	}
 }
 
@@ -509,12 +518,13 @@ func TestEvaluate_WarnAction(t *testing.T) {
 	result := Evaluate(rule, event, "")
 	if result == nil {
 		t.Fatal("expected non-nil result for matching warn rule")
-	}
-	if result.PermissionDecision != "allow" {
-		t.Errorf("expected allow, got %q", result.PermissionDecision)
-	}
-	if result.PermissionDecisionReason != "Echo detected" {
-		t.Errorf("unexpected reason: %q", result.PermissionDecisionReason)
+	} else {
+		if result.PermissionDecision != "allow" {
+			t.Errorf("expected allow, got %q", result.PermissionDecision)
+		}
+		if result.PermissionDecisionReason != "Echo detected" {
+			t.Errorf("unexpected reason: %q", result.PermissionDecisionReason)
+		}
 	}
 }
 
@@ -534,9 +544,10 @@ func TestEvaluate_DefaultActionIsWarn(t *testing.T) {
 	result := Evaluate(rule, event, "")
 	if result == nil {
 		t.Fatal("expected non-nil result")
-	}
-	if result.PermissionDecision != "allow" {
-		t.Errorf("expected default action to be allow (warn), got %q", result.PermissionDecision)
+	} else {
+		if result.PermissionDecision != "allow" {
+			t.Errorf("expected default action to be allow (warn), got %q", result.PermissionDecision)
+		}
 	}
 }
 
@@ -577,10 +588,7 @@ func TestEvaluate_ANDLogic_AllMatch(t *testing.T) {
 		},
 	}
 
-	result := Evaluate(rule, event, "")
-	if result == nil {
-		t.Fatal("expected non-nil result when all conditions match")
-	}
+	result := requireWorkflowResult(t, Evaluate(rule, event, ""), "expected non-nil result when all conditions match")
 	if result.PermissionDecision != "deny" {
 		t.Errorf("expected deny, got %q", result.PermissionDecision)
 	}
@@ -618,10 +626,7 @@ func TestEvaluate_EmptyConditions(t *testing.T) {
 	}
 	event := &schema.Event{}
 
-	result := Evaluate(rule, event, "")
-	if result == nil {
-		t.Fatal("expected non-nil result for rule with no conditions (vacuously true)")
-	}
+	result := requireWorkflowResult(t, Evaluate(rule, event, ""), "expected non-nil result for rule with no conditions (vacuously true)")
 	if result.PermissionDecision != "deny" {
 		t.Errorf("expected deny, got %q", result.PermissionDecision)
 	}
@@ -641,10 +646,7 @@ func TestEvaluate_EmptyMessageDefaultsToName(t *testing.T) {
 		Args: map[string]interface{}{"command": "test"},
 	}}
 
-	result := Evaluate(rule, event, "")
-	if result == nil {
-		t.Fatal("expected non-nil result")
-	}
+	result := requireWorkflowResult(t, Evaluate(rule, event, ""), "expected non-nil result")
 	if result.PermissionDecisionReason != `Hookify rule "my-rule" triggered` {
 		t.Errorf("expected default reason with rule name, got %q", result.PermissionDecisionReason)
 	}
@@ -668,10 +670,7 @@ func TestEvaluate_TranscriptCondition(t *testing.T) {
 			},
 			Message: "Tests were run",
 		}
-		result := Evaluate(rule, &schema.Event{}, dir)
-		if result == nil {
-			t.Fatal("expected non-nil result for transcript match")
-		}
+		result := requireWorkflowResult(t, Evaluate(rule, &schema.Event{}, dir), "expected non-nil result for transcript match")
 		if result.PermissionDecision != "allow" {
 			t.Errorf("expected allow, got %q", result.PermissionDecision)
 		}
@@ -686,10 +685,7 @@ func TestEvaluate_TranscriptCondition(t *testing.T) {
 			},
 			Message: "Go tests not run",
 		}
-		result := Evaluate(rule, &schema.Event{}, dir)
-		if result == nil {
-			t.Fatal("expected non-nil result for transcript not_contains match")
-		}
+		result := requireWorkflowResult(t, Evaluate(rule, &schema.Event{}, dir), "expected non-nil result for transcript not_contains match")
 		if result.PermissionDecision != "deny" {
 			t.Errorf("expected deny, got %q", result.PermissionDecision)
 		}
@@ -766,10 +762,7 @@ func TestEvaluate_OldTextField(t *testing.T) {
 		},
 	}}
 
-	result := Evaluate(rule, event, "")
-	if result == nil {
-		t.Fatal("expected non-nil result for old_text match")
-	}
+	result := requireWorkflowResult(t, Evaluate(rule, event, ""), "expected non-nil result for old_text match")
 	if result.PermissionDecision != "allow" {
 		t.Errorf("expected allow (warn), got %q", result.PermissionDecision)
 	}
@@ -792,10 +785,7 @@ func TestEvaluate_ContentFieldConcatenation(t *testing.T) {
 		},
 	}}
 
-	result := Evaluate(rule, event, "")
-	if result == nil {
-		t.Fatal("expected non-nil result when content contains password")
-	}
+	result := requireWorkflowResult(t, Evaluate(rule, event, ""), "expected non-nil result when content contains password")
 	if result.PermissionDecision != "deny" {
 		t.Errorf("expected deny, got %q", result.PermissionDecision)
 	}
@@ -821,10 +811,7 @@ func TestEvaluate_MultipleConditionsAllOperators(t *testing.T) {
 				Content: "console.log('debug')",
 			},
 		}
-		result := Evaluate(rule, event, "")
-		if result == nil {
-			t.Fatal("expected deny when all conditions match")
-		}
+		result := requireWorkflowResult(t, Evaluate(rule, event, ""), "expected deny when all conditions match")
 		if result.PermissionDecision != "deny" {
 			t.Errorf("expected deny, got %q", result.PermissionDecision)
 		}
@@ -896,10 +883,7 @@ func TestEvaluate_InjectAction(t *testing.T) {
 		},
 	}
 
-	result := Evaluate(rule, event, "")
-	if result == nil {
-		t.Fatal("expected non-nil result for inject action")
-	}
+	result := requireWorkflowResult(t, Evaluate(rule, event, ""), "expected non-nil result for inject action")
 	if result.PermissionDecision != "allow" {
 		t.Errorf("inject should allow, got %q", result.PermissionDecision)
 	}
@@ -921,10 +905,7 @@ func TestEvaluate_InjectAction_NoConditions(t *testing.T) {
 	}
 	event := &schema.Event{}
 
-	result := Evaluate(rule, event, "")
-	if result == nil {
-		t.Fatal("expected inject to fire with no conditions")
-	}
+	result := requireWorkflowResult(t, Evaluate(rule, event, ""), "expected inject to fire with no conditions")
 	if result.AdditionalContext != "Welcome! Remember to write tests." {
 		t.Errorf("unexpected AdditionalContext: %q", result.AdditionalContext)
 	}
@@ -949,10 +930,7 @@ func TestEvaluate_ContinueAction(t *testing.T) {
 		},
 	}
 
-	result := Evaluate(rule, event, "")
-	if result == nil {
-		t.Fatal("expected non-nil result for continue action")
-	}
+	result := requireWorkflowResult(t, Evaluate(rule, event, ""), "expected non-nil result for continue action")
 	if result.PermissionDecision != "deny" {
 		t.Errorf("continue should deny (prevent stop), got %q", result.PermissionDecision)
 	}
@@ -1013,10 +991,7 @@ func TestEvaluate_ModifyAction_Replace(t *testing.T) {
 		},
 	}
 
-	result := Evaluate(rule, event, "")
-	if result == nil {
-		t.Fatal("expected non-nil result for modify action")
-	}
+	result := requireWorkflowResult(t, Evaluate(rule, event, ""), "expected non-nil result for modify action")
 	if result.PermissionDecision != "allow" {
 		t.Errorf("modify should allow, got %q", result.PermissionDecision)
 	}
@@ -1050,10 +1025,7 @@ func TestEvaluate_ModifyAction_Prepend(t *testing.T) {
 		},
 	}
 
-	result := Evaluate(rule, event, "")
-	if result == nil {
-		t.Fatal("expected non-nil result for modify/prepend")
-	}
+	result := requireWorkflowResult(t, Evaluate(rule, event, ""), "expected non-nil result for modify/prepend")
 	if result.ModifiedArgs["command"] != "set -e && npm test" {
 		t.Errorf("expected prepended command, got %q", result.ModifiedArgs["command"])
 	}
@@ -1077,10 +1049,7 @@ func TestEvaluate_ModifyAction_Append(t *testing.T) {
 		},
 	}
 
-	result := Evaluate(rule, event, "")
-	if result == nil {
-		t.Fatal("expected non-nil result for modify/append")
-	}
+	result := requireWorkflowResult(t, Evaluate(rule, event, ""), "expected non-nil result for modify/append")
 	if result.ModifiedArgs["command"] != "go test ./... -v -count=1" {
 		t.Errorf("expected appended command, got %q", result.ModifiedArgs["command"])
 	}
@@ -1104,10 +1073,7 @@ func TestEvaluate_ModifyAction_Regex(t *testing.T) {
 		},
 	}
 
-	result := Evaluate(rule, event, "")
-	if result == nil {
-		t.Fatal("expected non-nil result for modify/regex")
-	}
+	result := requireWorkflowResult(t, Evaluate(rule, event, ""), "expected non-nil result for modify/regex")
 	if result.ModifiedArgs["command"] != "git checkout develop" {
 		t.Errorf("expected regex-modified command, got %q", result.ModifiedArgs["command"])
 	}
@@ -1131,10 +1097,7 @@ func TestEvaluate_ModifyAction_RegexInvalidFallback(t *testing.T) {
 		},
 	}
 
-	result := Evaluate(rule, event, "")
-	if result == nil {
-		t.Fatal("expected non-nil result")
-	}
+	result := requireWorkflowResult(t, Evaluate(rule, event, ""), "expected non-nil result")
 	// Invalid regex should leave value unchanged
 	if result.ModifiedArgs["command"] != "npm test" {
 		t.Errorf("invalid regex should leave value unchanged, got %q", result.ModifiedArgs["command"])
@@ -1160,10 +1123,7 @@ func TestEvaluate_ModifyAction_MissingTargetArg(t *testing.T) {
 		},
 	}
 
-	result := Evaluate(rule, event, "")
-	if result == nil {
-		t.Fatal("expected non-nil result")
-	}
+	result := requireWorkflowResult(t, Evaluate(rule, event, ""), "expected non-nil result")
 	if result.ModifiedArgs["description"] != "Auto-generated file" {
 		t.Errorf("expected new arg added, got %q", result.ModifiedArgs["description"])
 	}
@@ -1175,10 +1135,10 @@ func TestEvaluate_ModifyAction_MissingTargetArg(t *testing.T) {
 
 func TestApplyRegexStrategy(t *testing.T) {
 	tests := []struct {
-		name       string
-		current    string
-		content    string
-		expected   string
+		name     string
+		current  string
+		content  string
+		expected string
 	}{
 		{"sed-style replace", "hello world", "s/world/earth/", "hello earth"},
 		{"sed-style remove", "rm -rf /tmp", "s/ -rf//", "rm /tmp"},
@@ -1195,4 +1155,3 @@ func TestApplyRegexStrategy(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/hookify/evaluator_test.go
+++ b/internal/hookify/evaluator_test.go
@@ -874,3 +874,325 @@ func TestEvaluate_EmptyFieldValue(t *testing.T) {
 		t.Error("expected nil result when field value is empty and pattern is 'test'")
 	}
 }
+
+// --- Action type tests: inject, modify, continue ---
+
+func TestEvaluate_InjectAction(t *testing.T) {
+	rule := &Rule{
+		Name:   "inject-governance",
+		Action: ActionInject,
+		Conditions: []Condition{
+			{Field: FieldAgentName, Operator: OpContains, Pattern: "coding"},
+		},
+		Message: "You must follow the repo conventions. Never commit secrets.",
+	}
+	event := &schema.Event{
+		Hook: &schema.HookEvent{
+			Type: "subagentStart",
+			Tool: &schema.ToolEvent{
+				Name: "task",
+				Args: map[string]interface{}{"agentName": "coding-agent"},
+			},
+		},
+	}
+
+	result := Evaluate(rule, event, "")
+	if result == nil {
+		t.Fatal("expected non-nil result for inject action")
+	}
+	if result.PermissionDecision != "allow" {
+		t.Errorf("inject should allow, got %q", result.PermissionDecision)
+	}
+	if result.AdditionalContext != "You must follow the repo conventions. Never commit secrets." {
+		t.Errorf("inject AdditionalContext = %q, want rule message", result.AdditionalContext)
+	}
+	if result.PermissionDecisionReason != `Hookify rule "inject-governance" injected context` {
+		t.Errorf("unexpected reason: %q", result.PermissionDecisionReason)
+	}
+}
+
+func TestEvaluate_InjectAction_NoConditions(t *testing.T) {
+	// Inject with no conditions fires on every matching event (lifecycle hook)
+	rule := &Rule{
+		Name:       "session-inject",
+		Action:     ActionInject,
+		Conditions: []Condition{},
+		Message:    "Welcome! Remember to write tests.",
+	}
+	event := &schema.Event{}
+
+	result := Evaluate(rule, event, "")
+	if result == nil {
+		t.Fatal("expected inject to fire with no conditions")
+	}
+	if result.AdditionalContext != "Welcome! Remember to write tests." {
+		t.Errorf("unexpected AdditionalContext: %q", result.AdditionalContext)
+	}
+}
+
+func TestEvaluate_ContinueAction(t *testing.T) {
+	rule := &Rule{
+		Name:   "force-continue",
+		Action: ActionContinue,
+		Conditions: []Condition{
+			{Field: FieldMessage, Operator: OpContains, Pattern: "task incomplete"},
+		},
+		Message: "You're not done yet. Continue working on the remaining items.",
+	}
+	event := &schema.Event{
+		Hook: &schema.HookEvent{
+			Type: "agentStop",
+			Tool: &schema.ToolEvent{
+				Name: "agentStop",
+				Args: map[string]interface{}{"message": "task incomplete, but stopping"},
+			},
+		},
+	}
+
+	result := Evaluate(rule, event, "")
+	if result == nil {
+		t.Fatal("expected non-nil result for continue action")
+	}
+	if result.PermissionDecision != "deny" {
+		t.Errorf("continue should deny (prevent stop), got %q", result.PermissionDecision)
+	}
+	if !result.ContinueAgent {
+		t.Error("ContinueAgent should be true")
+	}
+	if result.ContinuePrompt != "You're not done yet. Continue working on the remaining items." {
+		t.Errorf("ContinuePrompt = %q, want the rule message body", result.ContinuePrompt)
+	}
+	if result.PermissionDecisionReason != `Hookify rule "force-continue" forced continuation` {
+		t.Errorf("unexpected reason: %q", result.PermissionDecisionReason)
+	}
+}
+
+func TestEvaluate_ContinueAction_NoMatch(t *testing.T) {
+	rule := &Rule{
+		Name:   "force-continue",
+		Action: ActionContinue,
+		Conditions: []Condition{
+			{Field: FieldMessage, Operator: OpContains, Pattern: "task incomplete"},
+		},
+		Message: "Keep going.",
+	}
+	event := &schema.Event{
+		Hook: &schema.HookEvent{
+			Type: "agentStop",
+			Tool: &schema.ToolEvent{
+				Name: "agentStop",
+				Args: map[string]interface{}{"message": "all done successfully"},
+			},
+		},
+	}
+
+	result := Evaluate(rule, event, "")
+	if result != nil {
+		t.Error("expected nil result when conditions don't match")
+	}
+}
+
+func TestEvaluate_ModifyAction_Replace(t *testing.T) {
+	rule := &Rule{
+		Name:           "sanitize-path",
+		Action:         ActionModify,
+		ModifyTarget:   "path",
+		ModifyStrategy: StrategyReplace,
+		Conditions: []Condition{
+			{Field: FieldToolName, Operator: OpEquals, Pattern: "create"},
+		},
+		Message: "/safe/path/output.txt",
+	}
+	event := &schema.Event{
+		Tool: &schema.ToolEvent{
+			Name: "create",
+			Args: map[string]interface{}{
+				"path":      "/dangerous/path/file.txt",
+				"file_text": "hello world",
+			},
+		},
+	}
+
+	result := Evaluate(rule, event, "")
+	if result == nil {
+		t.Fatal("expected non-nil result for modify action")
+	}
+	if result.PermissionDecision != "allow" {
+		t.Errorf("modify should allow, got %q", result.PermissionDecision)
+	}
+	if result.ModifiedArgs == nil {
+		t.Fatal("ModifiedArgs should not be nil")
+	}
+	if result.ModifiedArgs["path"] != "/safe/path/output.txt" {
+		t.Errorf("expected replaced path, got %q", result.ModifiedArgs["path"])
+	}
+	// Other args should be preserved
+	if result.ModifiedArgs["file_text"] != "hello world" {
+		t.Errorf("expected file_text preserved, got %q", result.ModifiedArgs["file_text"])
+	}
+}
+
+func TestEvaluate_ModifyAction_Prepend(t *testing.T) {
+	rule := &Rule{
+		Name:           "add-shebang",
+		Action:         ActionModify,
+		ModifyTarget:   "command",
+		ModifyStrategy: StrategyPrepend,
+		Conditions: []Condition{
+			{Field: FieldCommand, Operator: OpContains, Pattern: "npm"},
+		},
+		Message: "set -e && ",
+	}
+	event := &schema.Event{
+		Tool: &schema.ToolEvent{
+			Name: "bash",
+			Args: map[string]interface{}{"command": "npm test"},
+		},
+	}
+
+	result := Evaluate(rule, event, "")
+	if result == nil {
+		t.Fatal("expected non-nil result for modify/prepend")
+	}
+	if result.ModifiedArgs["command"] != "set -e && npm test" {
+		t.Errorf("expected prepended command, got %q", result.ModifiedArgs["command"])
+	}
+}
+
+func TestEvaluate_ModifyAction_Append(t *testing.T) {
+	rule := &Rule{
+		Name:           "add-verbose",
+		Action:         ActionModify,
+		ModifyTarget:   "command",
+		ModifyStrategy: StrategyAppend,
+		Conditions: []Condition{
+			{Field: FieldCommand, Operator: OpContains, Pattern: "go test"},
+		},
+		Message: " -v -count=1",
+	}
+	event := &schema.Event{
+		Tool: &schema.ToolEvent{
+			Name: "bash",
+			Args: map[string]interface{}{"command": "go test ./..."},
+		},
+	}
+
+	result := Evaluate(rule, event, "")
+	if result == nil {
+		t.Fatal("expected non-nil result for modify/append")
+	}
+	if result.ModifiedArgs["command"] != "go test ./... -v -count=1" {
+		t.Errorf("expected appended command, got %q", result.ModifiedArgs["command"])
+	}
+}
+
+func TestEvaluate_ModifyAction_Regex(t *testing.T) {
+	rule := &Rule{
+		Name:           "rewrite-branch",
+		Action:         ActionModify,
+		ModifyTarget:   "command",
+		ModifyStrategy: StrategyRegex,
+		Conditions: []Condition{
+			{Field: FieldCommand, Operator: OpContains, Pattern: "checkout"},
+		},
+		Message: "s/main/develop/",
+	}
+	event := &schema.Event{
+		Tool: &schema.ToolEvent{
+			Name: "bash",
+			Args: map[string]interface{}{"command": "git checkout main"},
+		},
+	}
+
+	result := Evaluate(rule, event, "")
+	if result == nil {
+		t.Fatal("expected non-nil result for modify/regex")
+	}
+	if result.ModifiedArgs["command"] != "git checkout develop" {
+		t.Errorf("expected regex-modified command, got %q", result.ModifiedArgs["command"])
+	}
+}
+
+func TestEvaluate_ModifyAction_RegexInvalidFallback(t *testing.T) {
+	rule := &Rule{
+		Name:           "bad-regex",
+		Action:         ActionModify,
+		ModifyTarget:   "command",
+		ModifyStrategy: StrategyRegex,
+		Conditions: []Condition{
+			{Field: FieldCommand, Operator: OpContains, Pattern: "test"},
+		},
+		Message: "s/[invalid(/replacement/",
+	}
+	event := &schema.Event{
+		Tool: &schema.ToolEvent{
+			Name: "bash",
+			Args: map[string]interface{}{"command": "npm test"},
+		},
+	}
+
+	result := Evaluate(rule, event, "")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	// Invalid regex should leave value unchanged
+	if result.ModifiedArgs["command"] != "npm test" {
+		t.Errorf("invalid regex should leave value unchanged, got %q", result.ModifiedArgs["command"])
+	}
+}
+
+func TestEvaluate_ModifyAction_MissingTargetArg(t *testing.T) {
+	// When the target arg doesn't exist, treat as empty string
+	rule := &Rule{
+		Name:           "add-description",
+		Action:         ActionModify,
+		ModifyTarget:   "description",
+		ModifyStrategy: StrategyReplace,
+		Conditions: []Condition{
+			{Field: FieldToolName, Operator: OpEquals, Pattern: "create"},
+		},
+		Message: "Auto-generated file",
+	}
+	event := &schema.Event{
+		Tool: &schema.ToolEvent{
+			Name: "create",
+			Args: map[string]interface{}{"path": "/tmp/file.txt"},
+		},
+	}
+
+	result := Evaluate(rule, event, "")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.ModifiedArgs["description"] != "Auto-generated file" {
+		t.Errorf("expected new arg added, got %q", result.ModifiedArgs["description"])
+	}
+	// Original arg preserved
+	if result.ModifiedArgs["path"] != "/tmp/file.txt" {
+		t.Errorf("expected path preserved, got %q", result.ModifiedArgs["path"])
+	}
+}
+
+func TestApplyRegexStrategy(t *testing.T) {
+	tests := []struct {
+		name       string
+		current    string
+		content    string
+		expected   string
+	}{
+		{"sed-style replace", "hello world", "s/world/earth/", "hello earth"},
+		{"sed-style remove", "rm -rf /tmp", "s/ -rf//", "rm /tmp"},
+		{"sed-style regex groups", "file_v2.txt", `s/v(\d+)/v99/`, "file_v99.txt"},
+		{"non-sed fallback", "anything", "replaced", "replaced"},
+		{"empty current sed", "", "s/^/prefix/", "prefix"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := applyRegexStrategy(tt.current, tt.content)
+			if result != tt.expected {
+				t.Errorf("applyRegexStrategy(%q, %q) = %q, want %q", tt.current, tt.content, result, tt.expected)
+			}
+		})
+	}
+}
+

--- a/internal/hookify/matcher.go
+++ b/internal/hookify/matcher.go
@@ -50,9 +50,28 @@ func matchEventType(eventType string, event *schema.Event) bool {
 		}
 		return false
 
-	case EventStop, EventPrompt:
-		// Deferred — hookflow doesn't have stop/prompt hooks
-		return false
+	case EventStop:
+		// "stop" is an alias for agentStop and subagentStop
+		if event.Hook == nil {
+			return false
+		}
+		return StopAliasEvents[event.Hook.Type]
+
+	case EventPrompt:
+		// "prompt" maps to userPromptSubmitted
+		if event.Hook == nil {
+			return false
+		}
+		return event.Hook.Type == "userPromptSubmitted"
+
+	// Direct Copilot CLI hook event type matching (1:1)
+	case EventSessionStart, EventSessionEnd, EventPreToolUse, EventPostToolUse,
+		EventPostToolUseFail, EventAgentStop, EventSubagentStart, EventSubagentStop,
+		EventPermissionRequest, EventNotification, EventPreCompact, EventErrorOccurred:
+		if event.Hook == nil {
+			return false
+		}
+		return event.Hook.Type == eventType
 
 	default:
 		return false

--- a/internal/hookify/parser.go
+++ b/internal/hookify/parser.go
@@ -101,6 +101,19 @@ func validateRule(rule *Rule) error {
 		return fmt.Errorf("hookify rule %q has invalid action: %q", rule.Name, rule.Action)
 	}
 
+	// Validate modify action has required fields
+	if rule.Action == ActionModify {
+		if rule.ModifyTarget == "" {
+			return fmt.Errorf("hookify rule %q with action %q requires modify_target field", rule.Name, ActionModify)
+		}
+		if rule.ModifyStrategy == "" {
+			return fmt.Errorf("hookify rule %q with action %q requires modify_strategy field", rule.Name, ActionModify)
+		}
+		if !ValidModifyStrategies[rule.ModifyStrategy] {
+			return fmt.Errorf("hookify rule %q has invalid modify_strategy: %q (must be prepend, append, replace, or regex)", rule.Name, rule.ModifyStrategy)
+		}
+	}
+
 	// Events in NoConditionEvents can omit pattern/conditions (pure-event trigger).
 	// Traditional events (bash, file) require pattern or conditions for filtering.
 	needsCondition := !NoConditionEvents[rule.Event]

--- a/internal/hookify/parser.go
+++ b/internal/hookify/parser.go
@@ -100,8 +100,14 @@ func validateRule(rule *Rule) error {
 	if rule.Action != "" && !ValidActions[rule.Action] {
 		return fmt.Errorf("hookify rule %q has invalid action: %q", rule.Name, rule.Action)
 	}
-	if rule.Pattern == "" && len(rule.Conditions) == 0 {
-		return fmt.Errorf("hookify rule %q must have either pattern or conditions", rule.Name)
+
+	// Events in NoConditionEvents can omit pattern/conditions (pure-event trigger).
+	// Traditional events (bash, file) require pattern or conditions for filtering.
+	needsCondition := !NoConditionEvents[rule.Event]
+	if needsCondition {
+		if rule.Pattern == "" && len(rule.Conditions) == 0 {
+			return fmt.Errorf("hookify rule %q must have either pattern or conditions", rule.Name)
+		}
 	}
 	if rule.Pattern != "" && len(rule.Conditions) > 0 {
 		return fmt.Errorf("hookify rule %q cannot have both pattern and conditions", rule.Name)

--- a/internal/hookify/parser_test.go
+++ b/internal/hookify/parser_test.go
@@ -714,3 +714,195 @@ Msg.
 		t.Errorf("expected field %q, got %q", FieldFilePath, rule.Conditions[0].Field)
 	}
 }
+
+// --- Tests for inject, modify, continue action parsing ---
+
+func TestParseRuleFromBytes_InjectAction(t *testing.T) {
+	input := `---
+name: inject-context
+event: subagentStart
+action: inject
+conditions:
+  - field: agent_name
+    operator: contains
+    pattern: coding
+---
+
+You must follow these rules:
+1. Never commit secrets
+2. Always write tests
+`
+	rule, err := ParseRuleFromBytes([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rule.Action != ActionInject {
+		t.Errorf("expected action %q, got %q", ActionInject, rule.Action)
+	}
+	if rule.Message != "You must follow these rules:\n1. Never commit secrets\n2. Always write tests" {
+		t.Errorf("unexpected message: %q", rule.Message)
+	}
+}
+
+func TestParseRuleFromBytes_ContinueAction(t *testing.T) {
+	input := `---
+name: force-continue
+event: agentStop
+action: continue
+conditions:
+  - field: message
+    operator: contains
+    pattern: incomplete
+---
+
+You are not done yet. Continue working on the remaining tasks.
+`
+	rule, err := ParseRuleFromBytes([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rule.Action != ActionContinue {
+		t.Errorf("expected action %q, got %q", ActionContinue, rule.Action)
+	}
+	if rule.Message != "You are not done yet. Continue working on the remaining tasks." {
+		t.Errorf("unexpected message: %q", rule.Message)
+	}
+}
+
+func TestParseRuleFromBytes_ModifyAction_Valid(t *testing.T) {
+	input := `---
+name: sanitize-command
+event: bash
+action: modify
+modify_target: command
+modify_strategy: prepend
+pattern: npm
+---
+
+set -e &&` + " " + `
+`
+	rule, err := ParseRuleFromBytes([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rule.Action != ActionModify {
+		t.Errorf("expected action %q, got %q", ActionModify, rule.Action)
+	}
+	if rule.ModifyTarget != "command" {
+		t.Errorf("expected modify_target %q, got %q", "command", rule.ModifyTarget)
+	}
+	if rule.ModifyStrategy != StrategyPrepend {
+		t.Errorf("expected modify_strategy %q, got %q", StrategyPrepend, rule.ModifyStrategy)
+	}
+}
+
+func TestParseRuleFromBytes_ModifyAction_MissingTarget(t *testing.T) {
+	input := `---
+name: bad-modify
+event: bash
+action: modify
+modify_strategy: replace
+pattern: test
+---
+
+replacement
+`
+	_, err := ParseRuleFromBytes([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for modify action without modify_target")
+	}
+	if !strings.Contains(err.Error(), "modify_target") {
+		t.Errorf("error should mention modify_target, got: %v", err)
+	}
+}
+
+func TestParseRuleFromBytes_ModifyAction_MissingStrategy(t *testing.T) {
+	input := `---
+name: bad-modify
+event: bash
+action: modify
+modify_target: command
+pattern: test
+---
+
+replacement
+`
+	_, err := ParseRuleFromBytes([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for modify action without modify_strategy")
+	}
+	if !strings.Contains(err.Error(), "modify_strategy") {
+		t.Errorf("error should mention modify_strategy, got: %v", err)
+	}
+}
+
+func TestParseRuleFromBytes_ModifyAction_InvalidStrategy(t *testing.T) {
+	input := `---
+name: bad-modify
+event: bash
+action: modify
+modify_target: command
+modify_strategy: invalid_strategy
+pattern: test
+---
+
+replacement
+`
+	_, err := ParseRuleFromBytes([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for invalid modify_strategy")
+	}
+	if !strings.Contains(err.Error(), "invalid modify_strategy") {
+		t.Errorf("error should mention invalid strategy, got: %v", err)
+	}
+}
+
+func TestParseRuleFromBytes_ModifyAction_AllStrategies(t *testing.T) {
+	strategies := []string{StrategyPrepend, StrategyAppend, StrategyReplace, StrategyRegex}
+	for _, strategy := range strategies {
+		t.Run(strategy, func(t *testing.T) {
+			input := fmt.Sprintf(`---
+name: modify-%s
+event: bash
+action: modify
+modify_target: command
+modify_strategy: %s
+pattern: test
+---
+
+content
+`, strategy, strategy)
+			rule, err := ParseRuleFromBytes([]byte(input))
+			if err != nil {
+				t.Fatalf("unexpected error for strategy %q: %v", strategy, err)
+			}
+			if rule.ModifyStrategy != strategy {
+				t.Errorf("expected strategy %q, got %q", strategy, rule.ModifyStrategy)
+			}
+		})
+	}
+}
+
+func TestParseRuleFromBytes_ContinueAction_NoConditions(t *testing.T) {
+	// continue action with agentStop event should work without conditions
+	// (agentStop is in NoConditionEvents)
+	input := `---
+name: always-continue
+event: agentStop
+action: continue
+---
+
+Keep working until all tasks are complete.
+`
+	rule, err := ParseRuleFromBytes([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rule.Action != ActionContinue {
+		t.Errorf("expected action %q, got %q", ActionContinue, rule.Action)
+	}
+	if rule.Message != "Keep working until all tasks are complete." {
+		t.Errorf("unexpected message: %q", rule.Message)
+	}
+}
+

--- a/internal/hookify/types.go
+++ b/internal/hookify/types.go
@@ -3,18 +3,20 @@ package hookify
 // Rule represents a hookify-format governance rule parsed from a markdown file
 // with YAML frontmatter.
 type Rule struct {
-	Name          string      `yaml:"name"`
-	Description   string      `yaml:"description,omitempty"`
-	Enabled       *bool       `yaml:"enabled,omitempty"` // pointer to distinguish unset (default true) from explicit false
-	Event         string      `yaml:"event"`
-	Action        string      `yaml:"action,omitempty"` // block, warn, inject, modify, continue (default: warn)
-	Pattern       string      `yaml:"pattern,omitempty"`
-	Conditions    []Condition `yaml:"conditions,omitempty"`
-	ToolMatcher   string      `yaml:"tool_matcher,omitempty"` // optional regex to match tool name
-	Lifecycle     string      `yaml:"lifecycle,omitempty"`    // pre or post (default: pre)
-	Message       string      `yaml:"-"`                      // markdown body (not from YAML)
-	FilePath      string      `yaml:"-"`                      // source file path (not from YAML)
-	HookEventType string      `yaml:"-"`                      // resolved Copilot CLI hook event type (set at runtime)
+	Name           string      `yaml:"name"`
+	Description    string      `yaml:"description,omitempty"`
+	Enabled        *bool       `yaml:"enabled,omitempty"` // pointer to distinguish unset (default true) from explicit false
+	Event          string      `yaml:"event"`
+	Action         string      `yaml:"action,omitempty"` // block, warn, inject, modify, continue (default: warn)
+	Pattern        string      `yaml:"pattern,omitempty"`
+	Conditions     []Condition `yaml:"conditions,omitempty"`
+	ToolMatcher    string      `yaml:"tool_matcher,omitempty"` // optional regex to match tool name
+	Lifecycle      string      `yaml:"lifecycle,omitempty"`    // pre or post (default: pre)
+	ModifyTarget   string      `yaml:"modify_target,omitempty"`   // for action=modify: which arg/field to modify
+	ModifyStrategy string      `yaml:"modify_strategy,omitempty"` // for action=modify: prepend, append, replace, regex
+	Message        string      `yaml:"-"`                      // markdown body (not from YAML)
+	FilePath       string      `yaml:"-"`                      // source file path (not from YAML)
+	HookEventType  string      `yaml:"-"`                      // resolved Copilot CLI hook event type (set at runtime)
 }
 
 // IsEnabled returns whether the rule is enabled (default: true).
@@ -86,6 +88,22 @@ const (
 	LifecyclePre  = "pre"
 	LifecyclePost = "post"
 )
+
+// Modify strategy constants
+const (
+	StrategyPrepend = "prepend"
+	StrategyAppend  = "append"
+	StrategyReplace = "replace"
+	StrategyRegex   = "regex"
+)
+
+// ValidModifyStrategies contains all recognized modify strategies.
+var ValidModifyStrategies = map[string]bool{
+	StrategyPrepend: true,
+	StrategyAppend:  true,
+	StrategyReplace: true,
+	StrategyRegex:   true,
+}
 
 // Operator constants
 const (

--- a/internal/hookify/types.go
+++ b/internal/hookify/types.go
@@ -3,17 +3,18 @@ package hookify
 // Rule represents a hookify-format governance rule parsed from a markdown file
 // with YAML frontmatter.
 type Rule struct {
-	Name         string      `yaml:"name"`
-	Description  string      `yaml:"description,omitempty"`
-	Enabled      *bool       `yaml:"enabled,omitempty"` // pointer to distinguish unset (default true) from explicit false
-	Event        string      `yaml:"event"`
-	Action       string      `yaml:"action,omitempty"` // block or warn (default: warn)
-	Pattern      string      `yaml:"pattern,omitempty"`
-	Conditions   []Condition `yaml:"conditions,omitempty"`
-	ToolMatcher  string      `yaml:"tool_matcher,omitempty"` // optional regex to match tool name
-	Lifecycle    string      `yaml:"lifecycle,omitempty"`    // pre or post (default: pre)
-	Message      string      `yaml:"-"`                      // markdown body (not from YAML)
-	FilePath     string      `yaml:"-"`                      // source file path (not from YAML)
+	Name          string      `yaml:"name"`
+	Description   string      `yaml:"description,omitempty"`
+	Enabled       *bool       `yaml:"enabled,omitempty"` // pointer to distinguish unset (default true) from explicit false
+	Event         string      `yaml:"event"`
+	Action        string      `yaml:"action,omitempty"` // block, warn, inject, modify, continue (default: warn)
+	Pattern       string      `yaml:"pattern,omitempty"`
+	Conditions    []Condition `yaml:"conditions,omitempty"`
+	ToolMatcher   string      `yaml:"tool_matcher,omitempty"` // optional regex to match tool name
+	Lifecycle     string      `yaml:"lifecycle,omitempty"`    // pre or post (default: pre)
+	Message       string      `yaml:"-"`                      // markdown body (not from YAML)
+	FilePath      string      `yaml:"-"`                      // source file path (not from YAML)
+	HookEventType string      `yaml:"-"`                      // resolved Copilot CLI hook event type (set at runtime)
 }
 
 // IsEnabled returns whether the rule is enabled (default: true).
@@ -48,19 +49,36 @@ type Condition struct {
 	Pattern  string `yaml:"pattern"`
 }
 
-// Event type constants
+// Event type constants — hookify aliases that map to Copilot CLI hook events
 const (
-	EventBash   = "bash"
-	EventFile   = "file"
-	EventAll    = "all"
-	EventStop   = "stop"   // deferred — hookflow doesn't have stop hooks
-	EventPrompt = "prompt" // deferred — hookflow doesn't have prompt hooks
+	EventBash   = "bash"   // shell tools: powershell, bash, shell, terminal
+	EventFile   = "file"   // file tools: create, edit
+	EventAll    = "all"    // matches any event type
+	EventStop   = "stop"   // agentStop / subagentStop events
+	EventPrompt = "prompt" // userPromptSubmitted event
+
+	// New Copilot CLI hook event types (1:1 mapping)
+	EventSessionStart      = "sessionStart"
+	EventSessionEnd        = "sessionEnd"
+	EventPreToolUse        = "preToolUse"
+	EventPostToolUse       = "postToolUse"
+	EventPostToolUseFail   = "postToolUseFailure"
+	EventAgentStop         = "agentStop"
+	EventSubagentStart     = "subagentStart"
+	EventSubagentStop      = "subagentStop"
+	EventPermissionRequest = "permissionRequest"
+	EventNotification      = "notification"
+	EventPreCompact        = "preCompact"
+	EventErrorOccurred     = "errorOccurred"
 )
 
 // Action constants
 const (
-	ActionBlock = "block"
-	ActionWarn  = "warn"
+	ActionBlock    = "block"
+	ActionWarn     = "warn"
+	ActionInject   = "inject"   // output additionalContext (for subagentStart, notification, sessionStart)
+	ActionModify   = "modify"   // output modifiedArgs (for preToolUse arg rewriting)
+	ActionContinue = "continue" // force agent to continue (for agentStop)
 )
 
 // Lifecycle constants
@@ -81,27 +99,50 @@ const (
 
 // Field constants — the hookify fields that can be checked in conditions
 const (
-	FieldCommand    = "command"
-	FieldFilePath   = "file_path"
-	FieldNewText    = "new_text"
-	FieldOldText    = "old_text"
-	FieldContent    = "content"
-	FieldTranscript = "transcript"
+	FieldCommand     = "command"
+	FieldFilePath    = "file_path"
+	FieldNewText     = "new_text"
+	FieldOldText     = "old_text"
+	FieldContent     = "content"
+	FieldTranscript  = "transcript"
+	FieldToolName    = "tool_name"    // name of the tool being invoked
+	FieldToolArgs    = "tool_args"    // JSON-encoded tool arguments
+	FieldAgentName   = "agent_name"   // subagentStart/subagentStop agent name
+	FieldAgentType   = "agent_type"   // subagentStart agent type
+	FieldMessage     = "message"      // notification message, error message
+	FieldHookEvent   = "hook_event"   // the Copilot CLI hook event type (e.g., "preToolUse")
+	FieldSessionID   = "session_id"   // session identifier
+	FieldToolResult  = "tool_result"  // postToolUse result content
 )
 
 // ValidEvents contains all recognized event types.
 var ValidEvents = map[string]bool{
-	EventBash:   true,
-	EventFile:   true,
-	EventAll:    true,
-	EventStop:   true,
-	EventPrompt: true,
+	EventBash:              true,
+	EventFile:              true,
+	EventAll:               true,
+	EventStop:              true,
+	EventPrompt:            true,
+	EventSessionStart:      true,
+	EventSessionEnd:        true,
+	EventPreToolUse:        true,
+	EventPostToolUse:       true,
+	EventPostToolUseFail:   true,
+	EventAgentStop:         true,
+	EventSubagentStart:     true,
+	EventSubagentStop:      true,
+	EventPermissionRequest: true,
+	EventNotification:      true,
+	EventPreCompact:        true,
+	EventErrorOccurred:     true,
 }
 
 // ValidActions contains all recognized action types.
 var ValidActions = map[string]bool{
-	ActionBlock: true,
-	ActionWarn:  true,
+	ActionBlock:    true,
+	ActionWarn:     true,
+	ActionInject:   true,
+	ActionModify:   true,
+	ActionContinue: true,
 }
 
 // ValidOperators contains all recognized condition operators.
@@ -122,6 +163,14 @@ var ValidFields = map[string]bool{
 	FieldOldText:    true,
 	FieldContent:    true,
 	FieldTranscript: true,
+	FieldToolName:   true,
+	FieldToolArgs:   true,
+	FieldAgentName:  true,
+	FieldAgentType:  true,
+	FieldMessage:    true,
+	FieldHookEvent:  true,
+	FieldSessionID:  true,
+	FieldToolResult: true,
 }
 
 // contentPositionalOperators are operators that depend on string position and
@@ -145,4 +194,26 @@ var BashToolNames = map[string]bool{
 var FileToolNames = map[string]bool{
 	"create": true,
 	"edit":   true,
+}
+
+// NoConditionEvents are event types that can fire without pattern/conditions.
+// These represent lifecycle or notification hooks where the event itself is the trigger.
+var NoConditionEvents = map[string]bool{
+	EventSessionStart:      true,
+	EventSessionEnd:        true,
+	EventAgentStop:         true,
+	EventSubagentStart:     true,
+	EventSubagentStop:      true,
+	EventPermissionRequest: true,
+	EventNotification:      true,
+	EventPreCompact:        true,
+	EventErrorOccurred:     true,
+	EventStop:              true,
+	EventPrompt:            true,
+}
+
+// StopAliasEvents are event types that the "stop" alias resolves to.
+var StopAliasEvents = map[string]bool{
+	EventAgentStop:    true,
+	EventSubagentStop: true,
 }

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -854,14 +854,14 @@ func TestIntegrationFullWorkflowPipeline(t *testing.T) {
 	// Step 3: Verify the result
 	if result == nil {
 		t.Fatal("WorkflowResult should not be nil")
-	}
+	} else {
+		// Result should be allow (even if steps had issues with continue-on-error)
+		if result.PermissionDecision != "allow" && result.PermissionDecision != "deny" {
+			t.Errorf("Invalid permission decision: %s", result.PermissionDecision)
+		}
 
-	// Result should be allow (even if steps had issues with continue-on-error)
-	if result.PermissionDecision != "allow" && result.PermissionDecision != "deny" {
-		t.Errorf("Invalid permission decision: %s", result.PermissionDecision)
+		t.Logf("Full pipeline completed: %s (reason: %s)", result.PermissionDecision, result.PermissionDecisionReason)
 	}
-
-	t.Logf("Full pipeline completed: %s (reason: %s)", result.PermissionDecision, result.PermissionDecisionReason)
 }
 
 // TestIntegrationEmptyWorkflowSteps tests a workflow that completes with no blocking issues

--- a/internal/schema/loader_test.go
+++ b/internal/schema/loader_test.go
@@ -202,9 +202,10 @@ func TestLoadAndValidateWorkflow_Valid(t *testing.T) {
 	}
 	if workflow == nil {
 		t.Fatal("Expected non-nil workflow")
-	}
-	if workflow.Name != "Lint JavaScript Files" {
-		t.Errorf("Expected name 'Lint JavaScript Files', got '%s'", workflow.Name)
+	} else {
+		if workflow.Name != "Lint JavaScript Files" {
+			t.Errorf("Expected name 'Lint JavaScript Files', got '%s'", workflow.Name)
+		}
 	}
 }
 

--- a/internal/schema/workflow.go
+++ b/internal/schema/workflow.go
@@ -162,6 +162,7 @@ type Event struct {
 	Cwd       string       `json:"cwd"`
 	Timestamp string       `json:"timestamp"`
 	Lifecycle string       `json:"lifecycle,omitempty"` // pre or post (defaults to pre)
+	SessionID string       `json:"sessionId,omitempty"` // Copilot CLI session identifier
 }
 
 // GetLifecycle returns the event lifecycle (defaults to "pre")
@@ -172,11 +173,16 @@ func (e *Event) GetLifecycle() string {
 	return e.Lifecycle
 }
 
-// HookEvent contains hook-specific event data
+// HookEvent contains hook-specific event data.
+// Type now holds any of the 13 Copilot CLI hook event types:
+// sessionStart, sessionEnd, userPromptSubmitted, preToolUse, postToolUse,
+// postToolUseFailure, agentStop, subagentStart, subagentStop,
+// permissionRequest, notification, preCompact, errorOccurred
 type HookEvent struct {
-	Type string     `json:"type"` // preToolUse, postToolUse
-	Tool *ToolEvent `json:"tool"`
-	Cwd  string     `json:"cwd"`
+	Type    string                 `json:"type"`              // The Copilot CLI hook event type
+	Tool    *ToolEvent             `json:"tool,omitempty"`    // Tool data (for preToolUse/postToolUse/postToolUseFailure)
+	Cwd     string                 `json:"cwd"`
+	Payload map[string]interface{} `json:"payload,omitempty"` // Raw hook payload fields for new event types
 }
 
 // ToolEvent contains tool invocation data
@@ -221,6 +227,8 @@ type WorkflowResult struct {
 	PermissionDecisionReason string `json:"permissionDecisionReason,omitempty"`
 	LogFile                  string `json:"logFile,omitempty"`    // Path to detailed log file
 	StepOutputs              string `json:"stepOutputs,omitempty"` // Combined step output for logging
+	AdditionalContext        string `json:"additionalContext,omitempty"` // Context injection for subagentStart, notification, sessionStart
+	ContinueAgent            bool   `json:"continueAgent,omitempty"`    // Force agent to continue (for agentStop override)
 }
 
 // NewAllowResult creates an allow result

--- a/internal/schema/workflow.go
+++ b/internal/schema/workflow.go
@@ -223,12 +223,14 @@ type FileStatus struct {
 
 // WorkflowResult represents the outcome of running a workflow
 type WorkflowResult struct {
-	PermissionDecision       string `json:"permissionDecision"` // allow, deny
-	PermissionDecisionReason string `json:"permissionDecisionReason,omitempty"`
-	LogFile                  string `json:"logFile,omitempty"`    // Path to detailed log file
-	StepOutputs              string `json:"stepOutputs,omitempty"` // Combined step output for logging
-	AdditionalContext        string `json:"additionalContext,omitempty"` // Context injection for subagentStart, notification, sessionStart
-	ContinueAgent            bool   `json:"continueAgent,omitempty"`    // Force agent to continue (for agentStop override)
+	PermissionDecision       string                 `json:"permissionDecision"` // allow, deny
+	PermissionDecisionReason string                 `json:"permissionDecisionReason,omitempty"`
+	LogFile                  string                 `json:"logFile,omitempty"`    // Path to detailed log file
+	StepOutputs              string                 `json:"stepOutputs,omitempty"` // Combined step output for logging
+	AdditionalContext        string                 `json:"additionalContext,omitempty"` // Context injection for subagentStart, notification, sessionStart
+	ContinueAgent            bool                   `json:"continueAgent,omitempty"`    // Force agent to continue (for agentStop override)
+	ContinuePrompt           string                 `json:"continuePrompt,omitempty"`   // The prompt to respond with when continuing
+	ModifiedArgs             map[string]interface{} `json:"modifiedArgs,omitempty"`     // Rewritten tool arguments (for preToolUse modify)
 }
 
 // NewAllowResult creates an allow result

--- a/testdata/e2e/hookflows/hookify-continue-agent.md
+++ b/testdata/e2e/hookflows/hookify-continue-agent.md
@@ -1,0 +1,12 @@
+---
+name: hookify-force-continue
+description: Force agent to continue when tasks are incomplete
+event: agentStop
+action: continue
+conditions:
+  - field: message
+    operator: contains
+    pattern: incomplete
+---
+
+You are not done yet. Review your task list and continue working on the remaining items. Do not stop until all tasks are marked complete.

--- a/testdata/e2e/hookflows/hookify-inject-context.md
+++ b/testdata/e2e/hookflows/hookify-inject-context.md
@@ -1,0 +1,18 @@
+---
+name: hookify-inject-governance
+description: Inject governance context into subagent starts
+event: subagentStart
+action: inject
+conditions:
+  - field: agent_name
+    operator: contains
+    pattern: coding
+---
+
+## Governance Rules
+
+You must follow these rules when operating as a subagent:
+1. Never commit secrets or API keys
+2. Always write tests for new functionality
+3. Follow the repo's established conventions
+4. Use dev-workflow tools instead of raw git commands

--- a/testdata/e2e/hookflows/hookify-modify-command.md
+++ b/testdata/e2e/hookflows/hookify-modify-command.md
@@ -1,0 +1,10 @@
+---
+name: hookify-modify-add-verbose
+description: Append verbose flag to go test commands
+event: bash
+action: modify
+modify_target: command
+modify_strategy: append
+pattern: go test
+---
+ -v -count=1


### PR DESCRIPTION
## Phase 1: Hookify New Events & Actions

### Summary
Expands the hookify engine to support all 13 Copilot CLI hook events, 3 new action types, and 8 new condition fields — transforming hookflow from a preToolUse/postToolUse-only engine into a full lifecycle governance platform.

### Changes

#### New Event Types (12 added)
- `sessionStart`, `sessionEnd`, `preToolUse`, `postToolUse`, `postToolUseFailure`
- `agentStop`, `subagentStart`, `subagentStop`
- `permissionRequest`, `notification`, `preCompact`, `errorOccurred`
- Aliases activated: `stop` → agentStop/subagentStop, `prompt` → userPromptSubmitted

#### New Action Types (3 added)
- **`inject`** — Output `additionalContext` (for subagentStart, notification, sessionStart governance)
- **`modify`** — Output `modifiedArgs` (for preToolUse arg rewriting)
- **`continue`** — Force agent continuation (for agentStop override)

#### New Condition Fields (8 added)
`tool_name`, `tool_args`, `agent_name`, `agent_type`, `message`, `hook_event`, `session_id`, `tool_result`

#### Schema Changes
- `WorkflowResult` gains `AdditionalContext` and `ContinueAgent` fields
- `Event` gains `SessionID`; `HookEvent` gains `Payload` map
- No-condition rules allowed for lifecycle events

#### CLI Changes
- `--event-type` flag now accepts all 13 event types
- `eventTypeToLifecycle()` correctly maps post-events (postToolUse, postToolUseFailure, sessionEnd, subagentStop)
- Full payload stored for non-tool events

### Testing
- All existing tests pass (0 regressions)
- `go test ./internal/...` ✅ (14 packages)
- `go test ./cmd/...` ✅
- `go build ./cmd/hookflow/... ./internal/...` ✅

### Files Changed (7)
- `internal/hookify/types.go` — Event/action/field constants and validation maps
- `internal/hookify/matcher.go` — Event type matching for all 13 events + aliases
- `internal/hookify/parser.go` — Allow no-condition rules for lifecycle events
- `internal/hookify/evaluator.go` — New action handlers + 8 field extractors
- `internal/schema/workflow.go` — WorkflowResult, Event, HookEvent expansions
- `cmd/hookflow/main.go` — CLI event-type handling, payload storage, context merging
- `cmd/hookflow/cmd_test.go` — Updated test calls for new function signature